### PR TITLE
feat(actions): bind gh to mousehover

### DIFF
--- a/vim/vscode-code-actions.vim
+++ b/vim/vscode-code-actions.vim
@@ -34,6 +34,11 @@ function! s:vscodeGoToDefinition()
     endif
 endfunction
 
+function! s:hover()
+  normal! gv
+  call VSCodeNotify('editor.action.showHover')
+endfunction
+
 command! -range -bar VSCodeCommentary call s:vscodeCommentary(<line1>, <line2>)
 
 xnoremap <expr> <Plug>VSCodeCommentary <SID>vscodeCommentary()
@@ -48,12 +53,14 @@ nnoremap <expr> == <SID>vscodeFormat() . '_'
 " gf/gF . Map to go to definition for now
 nnoremap <silent> gf :<C-u>call <SID>vscodeGoToDefinition()<CR>
 nnoremap <silent> gd :<C-u>call <SID>vscodeGoToDefinition()<CR>
+nnoremap <silent> gh :<C-u>call VSCodeNotify('editor.action.showHover')<CR>
 nnoremap <silent> <C-]> :<C-u>call <SID>vscodeGoToDefinition()<CR>
 nnoremap <silent> gF :<C-u>call VSCodeNotify('editor.action.peekDefinition')<CR>
 nnoremap <silent> gD :<C-u>call VSCodeNotify('editor.action.peekDefinition')<CR>
 
 xnoremap <silent> gf :<C-u>call <SID>vscodeGoToDefinition()<CR>
 xnoremap <silent> gd :<C-u>call <SID>vscodeGoToDefinition()<CR>
+xnoremap <silent> gh :<C-u>call <SID>hover()<CR>
 xnoremap <silent> <C-]> :<C-u>call <SID>vscodeGoToDefinition()<CR>
 xnoremap <silent> gF :<C-u>call VSCodeNotify('editor.action.peekDefinition')<CR>
 xnoremap <silent> gD :<C-u>call VSCodeNotify('editor.action.peekDefinition')<CR>


### PR DESCRIPTION
It's quite frequent usecases to use mousehover to see compiler error messages / or other information provided like below:

![image](https://user-images.githubusercontent.com/1210596/71082109-63db5500-2145-11ea-86a3-cd61547981e8.png)

This PR attempts to mimic vscodevim's keybinding, bringing `gh` to server as mouse hover in vscode.

Honestly not sure if this is desired changes (and as vim beginner unsure if there's predefined bindings), open to suggestions.

p.s: bumd q, is it possible user can configure this actions by own instead of upstream?