### PR TITLE
is137 Add settings for operating system specific paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,13 +40,51 @@
 					"type": "string",
 					"default": "",
 					"title": "Neovim path",
-					"description": "Full path to Neovim executable. If you have enabled useWSL specify the linux path to nvim executable"
+					"markdownDescription": "*Windows, OSX, Linux in Neovim path settings won`t work if this setting is set* Full path to Neovim executable. If you have enabled `useWSL` setting, specify the Linux path to nvim executable instead.",
+					"deprecationMessage": "This setting is deprecated. Remove this setting and use neovimExecutablePaths.win32/linux/darwin instead. If you continue to use this setting, keep in mind this setting takes precedence over neovimExecutablePaths.windows/linux/darwin and those settings won't work. If you want them to work, just remove this setting from your settings.json or make its input box in User Settings empty"
+				},
+				"vscode-neovim.neovimExecutablePaths.win32": {
+					"type": "string",
+					"default": "",
+					"title": "Neovim executable path on Windows",
+					"markdownDescription": "Full path to Neovim executable that should be used by the extension if running VS Code on Windows.  \nExample:  \nC:\\tools\\neovim\\Neovim\\bin\\nvim.exe (if you installed using Chocolatey)  \nIf you want to use Windows Subsystem for Linux, enable the `useWSL` setting and set `neovimExecutablePaths.linux` instead"
+				},
+				"vscode-neovim.neovimExecutablePaths.darwin": {
+					"type": "string",
+					"default": "",
+					"title": "Neovim executable path on OSX",
+					"description": "Full path to Neovim executable that should be used by the extension if running VS Code on OSX."
+				},
+				"vscode-neovim.neovimExecutablePaths.linux": {
+					"type": "string",
+					"default": "",
+					"title": "Neovim executable path on Linux (and in WSL)",
+					"markdownDescription": "Full path to Neovim executable that should be used by the extension if running VS Code on Linux or WSL. If `useWSL` setting is checked, vscode-neovim will look for this path in WSL  \nExample:  \n/usr/bin/nvim"
 				},
 				"vscode-neovim.neovimInitPath": {
 					"type": "string",
 					"default": "",
 					"title": "Custom init.vim path",
-					"description": "Full path to custom neovim init file, equals to startup option -u. If checked useWSL flag specify a Linux path. You can also use exists('g:vscode') in your init.vim to check if neovim is being run in vscode and share init file between neovim/vscode"
+					"description": "Full path to custom neovim init file, equals to startup option -u. If checked useWSL flag specify a Linux path. You can also use exists('g:vscode') in your init.vim to check if neovim is being run in vscode and share init file between neovim/vscode",
+					"deprecationMessage": "This setting is deprecated. Use neovimInitVimPaths.win32/linux/darwin instead. If you continue to use this setting, keep in mind this setting takes precedence over neovimInitVimPaths.win32/linux/darwin and those settings won't work. If you want them to work, just remove this setting from your settings.json or make its input box in User Settings empty"
+				},
+				"vscode-neovim.neovimInitVimPaths.win32": {
+					"type": "string",
+					"default": "",
+					"title": "Custom init.vim path on Windows",
+					"markdownDescription": "Full path to custom neovim init.vim file on Windows, equals to startup option `-u`. If the `useWSL` setting is checked, the value of the `neovimInitVimPaths.linux` setting will be used to find the init.vim file instead. You can also use `exists('g:vscode')` in your init.vim to check if neovim is being run in vscode and share init file between neovim/vscode"
+				},
+				"vscode-neovim.neovimInitVimPaths.darwin": {
+					"type": "string",
+					"default": "",
+					"title": "Custom init.vim path on OSX",
+					"markdownDescription": "Full path to custom neovim init.vim file on OSX, equals to startup option `-u`. You can also use `exists('g:vscode')` in your init.vim to check if neovim is being run in vscode and share init file between neovim/vscode"
+				},
+				"vscode-neovim.neovimInitVimPaths.linux": {
+					"type": "string",
+					"default": "",
+					"title": "Custom init.vim path on Linux",
+					"markdownDescription": "Full path to custom neovim init.vim file on Linux/WSL, equals to startup option `-u`. If the `useWSL` setting is checked, this path will be used to find `init.vim` in Windows Subsystem for Linux. You can also use `exists('g:vscode')` in your init.vim to check if neovim is being run in vscode and share init file between neovim/vscode"
 				},
 				"vscode-neovim.neovimWidth": {
 					"type": "number",
@@ -72,7 +110,7 @@
 				"vscode-neovim.useWSL": {
 					"type": "boolean",
 					"default": false,
-					"description": "Use neovim installed in WSL. If you enable it, specify neovim path installed in WSL"
+					"markdownDescription": "Use neovim installed in WSL. If you enable this setting, specify the path to the neovim executable installed in WSL `neovimExecutablePaths.linux` setting"
 				},
 				"vscode-neovim.highlightGroups.ignoreHighlights": {
 					"type": "array",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,16 +1,14 @@
 import * as vscode from "vscode";
 
 import { NVIMPluginController } from "./controller";
-
-const EXT_NAME = "vscode-neovim";
-const EXT_ID = `asvetliakov.${EXT_NAME}`;
+import { getNeovimPath, getNeovimInitPath, EXT_ID, EXT_NAME } from "./utils";
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
     const ext = vscode.extensions.getExtension(EXT_ID)!;
     const settings = vscode.workspace.getConfiguration(EXT_NAME);
-    const neovimPath = process.env.NEOVIM_PATH || settings.get("neovimPath");
+    const neovimPath = getNeovimPath();
     if (!neovimPath) {
         vscode.window.showErrorMessage("Neovim: configure the path to neovim and restart the editor");
         return;
@@ -23,7 +21,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     const useCtrlKeysInsertMode = settings.get("useCtrlKeysForInsertMode", true);
     const useWsl = settings.get("useWSL", false);
     const neovimWidth = settings.get("neovimWidth", 1000);
-    const customInit = settings.get("neovimInitPath", "");
+    const customInit = getNeovimInitPath() ?? "";
+
     vscode.commands.executeCommand("setContext", "neovim.ctrlKeysNormal", useCtrlKeysNormalMode);
     vscode.commands.executeCommand("setContext", "neovim.ctrlKeysInsert", useCtrlKeysInsertMode);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -370,13 +370,13 @@ export function getNeovimPath(): string | undefined {
     const legacySettingInfo = {
         vscodeSettingName: "neovimPath",
         environmentVariableName: "NEOVIM_PATH",
-    } as Parameters<typeof getSystemSpecificSetting>[1];
+    } as const;
     return getSystemSpecificSetting("neovimExecutablePaths", legacySettingInfo);
 }
 
 export function getNeovimInitPath(): string | undefined {
     const legacySettingInfo = {
         vscodeSettingName: "neovimInitPath",
-    } as Parameters<typeof getSystemSpecificSetting>[1];
+    } as const;
     return getSystemSpecificSetting("neovimInitVimPaths", legacySettingInfo);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -347,7 +347,7 @@ function getSystemSpecificSetting(
     legacySetting: { environmentVariableName?: "NEOVIM_PATH"; vscodeSettingName: LegacySettingName },
 ): string | undefined {
     const settings = workspace.getConfiguration(EXT_NAME);
-    const isWindowsSubsystemForLinux = settings.get("useWSL");
+    const isUseWindowsSubsystemForLinux = settings.get("useWSL");
 
     //https://github.com/microsoft/vscode/blob/master/src/vs/base/common/platform.ts#L63
     const platform = process.platform as "win32" | "darwin" | "linux";
@@ -359,7 +359,7 @@ function getSystemSpecificSetting(
     const legacySettingValue = legacyEnvironmentVariable || settings.get(legacySetting.vscodeSettingName);
     if (legacySettingValue) {
         return legacySettingValue;
-    } else if (isWindowsSubsystemForLinux) {
+    } else if (isUseWindowsSubsystemForLinux && platform !== "darwin") {
         return settings.get(`${settingPrefix}.${"linux" as Platform}`);
     } else {
         return settings.get(`${settingPrefix}.${platform}`);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -359,7 +359,7 @@ function getSystemSpecificSetting(
     const legacySettingValue = legacyEnvironmentVariable || settings.get(legacySetting.vscodeSettingName);
     if (legacySettingValue) {
         return legacySettingValue;
-    } else if (isUseWindowsSubsystemForLinux && platform !== "darwin") {
+    } else if (isUseWindowsSubsystemForLinux && platform === "win32") {
         return settings.get(`${settingPrefix}.${"linux" as Platform}`);
     } else {
         return settings.get(`${settingPrefix}.${platform}`);


### PR DESCRIPTION
Fixes #137 

This branch adds operating system specific paths (neovimPath). ~I still need to add some tests~ and actually manually check if it even works.

Anyways, I'm working on it. Uploading a draft PR as a heads up

- Create settings and logic for overriding settings on Windows, Linux and OSX:
  - [X] neovimPath
  - [X] neovimInitPath (logic is written but I didn't replace the logic in `extension.ts` yet
- [X] Update package.json setting descriptions
- [X] Mark neovimPath and neovimInitPath as deprecated in settings.json
- [ ] ~**Figure out how to mock `vscode.workspace.getConfiguration('vscode-nevoim')` in unit tests so I can write unit tests for that functionality**~

neovimPath and neovimInitPath logic is written here in such a way that if neovimPath exists, the system specific settings are ignored. So people who are oblivous to the deprecation of neovimPath won't have a broken workflow when this is merged.