### PR TITLE
[WIP] Use different method to send edits in insert mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -400,37 +400,37 @@
 			{
 				"command": "vscode-neovim.send",
 				"key": "backspace",
-				"when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+				"when": "editorTextFocus && neovim.init && neovim.mode != insert",
 				"args": "<BS>"
 			},
 			{
 				"command": "vscode-neovim.send",
 				"key": "shift+backspace",
-				"when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+				"when": "editorTextFocus && neovim.init && neovim.mode != insert",
 				"args": "<S-BS>"
 			},
 			{
 				"command": "vscode-neovim.send",
 				"key": "ctrl+backspace",
-				"when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+				"when": "editorTextFocus && neovim.init && neovim.mode != insert",
 				"args": "<C-BS>"
 			},
 			{
 				"command": "vscode-neovim.send",
 				"key": "delete",
-				"when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+				"when": "editorTextFocus && neovim.init && neovim.mode != insert",
 				"args": "<Del>"
 			},
 			{
 				"command": "vscode-neovim.send",
 				"key": "shift+delete",
-				"when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+				"when": "editorTextFocus && neovim.init && neovim.mode != insert",
 				"args": "<S-Del>"
 			},
 			{
 				"command": "vscode-neovim.send",
 				"key": "ctrl+delete",
-				"when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+				"when": "editorTextFocus && neovim.init && neovim.mode != insert",
 				"args": "<C-Del>"
 			},
 			{
@@ -448,37 +448,37 @@
 			{
 				"command": "vscode-neovim.send",
 				"key": "down",
-				"when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+				"when": "editorTextFocus && neovim.init && neovim.mode != insert",
 				"args": "<Down>"
 			},
 			{
 				"command": "vscode-neovim.send",
 				"key": "up",
-				"when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+				"when": "editorTextFocus && neovim.init && neovim.mode != insert",
 				"args": "<Up>"
 			},
 			{
 				"command": "vscode-neovim.send",
 				"key": "left",
-				"when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+				"when": "editorTextFocus && neovim.init && neovim.mode != insert",
 				"args": "<Left>"
 			},
 			{
 				"command": "vscode-neovim.send",
 				"key": "right",
-				"when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+				"when": "editorTextFocus && neovim.init && neovim.mode != insert",
 				"args": "<Right>"
 			},
 			{
 				"command": "vscode-neovim.send",
 				"key": "ctrl+right",
-				"when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+				"when": "editorTextFocus && neovim.init && neovim.mode != insert",
 				"args": "<C-Right>"
 			},
 			{
 				"command": "vscode-neovim.send",
 				"key": "ctrl+left",
-				"when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+				"when": "editorTextFocus && neovim.init && neovim.mode != insert",
 				"args": "<C-Left>"
 			},
 			{
@@ -598,354 +598,354 @@
 			{
 				"command": "deleteAllLeft",
 				"key": "ctrl-u",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert"
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert"
 			},
 			{
 				"command": "vscode-neovim.send",
 				"key": "ctrl+u",
-				"when": "editorTextFocus && neovim.mode == insert && neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "<C-u>"
 			},
 			{
 				"command": "deleteWordLeft",
 				"key": "ctrl+w",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert"
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert"
 			},
 			{
 				"command": "vscode-neovim.send",
 				"key": "ctrl+w",
-				"when": "editorTextFocus && neovim.mode == insert && neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "<C-w>"
 			},
 			{
 				"command": "deleteLeft",
 				"key": "ctrl+h",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert"
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert"
 			},
 			{
 				"command": "vscode-neovim.send",
 				"key": "ctrl+h",
-				"when": "editorTextFocus && neovim.mode == insert && neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "<C-j>"
 			},
 			{
 				"command": "editor.action.indentLines",
 				"key": "ctrl+t",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert"
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert"
 			},
 			{
 				"command": "vscode-neovim.send",
 				"key": "ctrl+t",
-				"when": "editorTextFocus && neovim.mode == insert && neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "<C-t>"
 			},
 			{
 				"command": "editor.action.outdentLines",
 				"key": "ctrl+d",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert"
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert"
 			},
 			{
 				"command": "vscode-neovim.send",
 				"key": "ctrl+d",
-				"when": "editorTextFocus && neovim.mode == insert && neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "<C-d>"
 			},
 			{
 				"command": "editor.action.insertLineAfter",
 				"key": "ctrl+j",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert"
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert"
 			},
 			{
 				"command": "vscode-neovim.send",
 				"key": "ctrl+j",
-				"when": "editorTextFocus && neovim.mode == insert && neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "<C-j>"
 			},
 			{
 				"command": "vscode-neovim.ctrl-a-insert",
 				"key": "ctrl+a",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert"
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert"
 			},
 			{
 				"command": "vscode-neovim.send",
 				"key": "ctrl+a",
-				"when": "editorTextFocus && neovim.mode == insert && neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "<C-a>"
 			},
 			{
 				"command": "vscode-neovim.send",
 				"key": "ctrl+r",
-				"when": "editorTextFocus && neovim.mode == insert && neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "<C-r>"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r 0",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "0"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r 1",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "1"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r 2",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "2"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r 3",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "3"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r 4",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "4"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r 5",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "5"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r 6",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "6"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r 7",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "7"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r 8",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "8"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r 9",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "9"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r shift-'",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "\""
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r shift-5",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "%"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r shift-3",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "#"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r shift-8",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "*"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r shift-=",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "+"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r shift-;",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": ":"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r .",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "."
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r -",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "-"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r =",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "="
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r ka",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "a"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r b",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "b"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r c",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "c"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r d",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "d"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r e",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "e"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r f",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "f"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r g",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "g"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r h",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "h"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r i",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "i"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r j",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "j"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r k",
-				"when": "editorTextFocus && neovim.mode == insert &&& !neovim.recording & neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "k"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r l",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "l"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r m",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "m"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r n",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "n"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r o",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "o"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r p",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "p"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r q",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "q"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r r",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "r"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r s",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "s"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r t",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "t"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r u",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "u"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r v",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "v"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r w",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "w"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r x",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "x"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r y",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "y"
 			},
 			{
 				"command": "vscode-neovim.paste-register",
 				"key": "ctrl+r z",
-				"when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+				"when": "editorTextFocus && neovim.mode == insert && neovim.ctrlKeysInsert",
 				"args": "z"
 			}
 		]

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -538,7 +538,7 @@ export class NVIMPluginController implements vscode.Disposable {
                         "nvim_win_set_cursor",
                         [0, this.getNeovimCursorPosForEditor(vscode.window.activeTextEditor, change.range.start)],
                     ]);
-                    edits.push(["nvim_paste", [change.text.split(eol).join("\n"), false, -1]]);
+                    edits.push(["nvim_paste", [change.text, true, -1]]);
                     // paste is single tick
                     skipTickCount++;
                 }

--- a/vim/vscode-neovim.vim
+++ b/vim/vscode-neovim.vim
@@ -144,14 +144,6 @@ function! s:runFileTypeDetection()
     set syntax=off
 endfunction
 
-function! s:onInsertEnter()
-    let reg = reg_recording()
-    if reg != ""
-        call VSCodeExtensionCall('notify-recording', reg)
-    endif
-endfunction
-
-
 " Load altercmd first
 execute 'source ' . s:currDir . '/vim-altercmd/plugin/altercmd.vim'
 execute 'source ' . s:currDir . '/vscode-insert.vim'
@@ -167,7 +159,6 @@ autocmd BufEnter * call <SID>onBufEnter(expand('<afile>'), expand('<abuf>'))
 " Help and other buffer types may explicitly disable line numbers - reenable them, !important - set nowrap since it may be overriden and this option is crucial for now
 autocmd FileType * :setlocal conceallevel=0 | :setlocal number | :setlocal numberwidth=8 | :setlocal nowrap | :setlocal nofoldenable
 autocmd WinEnter * call <SID>onWinEnter()
-autocmd InsertEnter * call <SID>onInsertEnter()
 autocmd BufAdd * call <SID>runFileTypeDetection()
 " Looks like external windows are coming with "set wrap" set automatically, disable them
 autocmd WinNew,WinEnter * :set nowrap

--- a/vim/vscode-options.vim
+++ b/vim/vscode-options.vim
@@ -44,3 +44,7 @@ set modelines=0
 " Turn off auto-folding
 set nofoldenable
 set foldmethod='manual'
+
+" Turn off smart/auto-indenting
+set noautoindent
+set nosmartindent

--- a/vim/vscode-options.vim
+++ b/vim/vscode-options.vim
@@ -48,3 +48,6 @@ set foldmethod='manual'
 " Turn off smart/auto-indenting
 set noautoindent
 set nosmartindent
+
+" Remove indent from backspace otherwise it will break things
+set backspace=eol,start


### PR DESCRIPTION
*Not ready for daily use yet*

Experimental workaround for dot-repeat operation. Instead `nvim_buf_set_lines` it tries to set cursor position and call `nvim_input` with delete & text keystokes

- Doesn't work with multi-byte characters now
- Text deletion is performed only by `<BS>` keys. This matters for dot-repeat operator (i.e. delete left or right) but no way to workaround this.

Will provide soon vsix file for testing

Fixes #76 