### PR TITLE
Workaround dot-repeat by replaying last changes in separate buffer

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -60,10 +60,6 @@ interface RequestResponse {
     send(resp: unknown, isError?: boolean): void;
 }
 
-interface ActiveChange {
-    delLength: number;
-}
-
 // to not deal with screenrow positioning, we set height to high value and scrolloff to value / 2. so screenrow will be always constant
 // big scrolloff is needed to make sure that editor visible space will be always within virtual vim boundaries, regardless of current
 // cursor positioning
@@ -2306,7 +2302,6 @@ export class NVIMPluginController implements vscode.Disposable {
         if (!this.isInit) {
             return;
         }
-        // need <Esc> first otherwise it won't allow to switch the buffer
         if (this.isInsertMode) {
             this.leaveMultipleCursorsForVisualMode = false;
             await this.uploadDocumentChangesToNeovim();

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -60,6 +60,10 @@ interface RequestResponse {
     send(resp: unknown, isError?: boolean): void;
 }
 
+interface ActiveChange {
+    delLength: number;
+}
+
 // to not deal with screenrow positioning, we set height to high value and scrolloff to value / 2. so screenrow will be always constant
 // big scrolloff is needed to make sure that editor visible space will be always within virtual vim boundaries, regardless of current
 // cursor positioning
@@ -125,6 +129,10 @@ export class NVIMPluginController implements vscode.Disposable {
      */
     private documentChangesInInsertMode: Map<string, boolean> = new Map();
     private documentText: Map<string, string> = new Map();
+    /**
+     * Last subsequent related changes. Used for dot-repeat workaround
+     */
+    private lastChanges: vscode.TextDocumentContentChangeEvent[] = [];
     /**
      * Vscode doesn't allow to apply multiple edits to the save document without awaiting previous reuslt.
      * So we'll accumulate neovim buffer updates here, then apply
@@ -493,6 +501,26 @@ export class NVIMPluginController implements vscode.Disposable {
         }
         if (!this.managedBufferIds.has(buf.id)) {
             return;
+        }
+        const currEditor = vscode.window.activeTextEditor;
+        if (
+            currEditor &&
+            currEditor.document.uri.toString() === e.document.uri.toString() &&
+            this.isInsertMode &&
+            this.editorColumnIdToWinId.get(currEditor.viewColumn || -1)
+        ) {
+            const eol = currEditor.document.eol === vscode.EndOfLine.LF ? "\n" : "\r\n";
+            const cursor = currEditor.selection.active;
+            for (const change of e.contentChanges) {
+                if (Utils.isCursorChange(change, cursor, eol)) {
+                    const lastChange = this.lastChanges.slice(-1)[0];
+                    if (lastChange && Utils.isChangeSubsequentToChange(change, lastChange)) {
+                        this.lastChanges.push(change);
+                    } else {
+                        this.lastChanges = [change];
+                    }
+                }
+            }
         }
         const changed = this.documentChangesInInsertMode.get(uri);
         if (!changed) {
@@ -2118,6 +2146,75 @@ export class NVIMPluginController implements vscode.Disposable {
         return res;
     };
 
+    private syncLastChangesWithDotRepeat = async (): Promise<void> => {
+        // dot-repeat executes last change across all buffers. So we'll create a temporary buffer & window,
+        // replay last changes here to trick neovim and destroy it after
+        if (!this.lastChanges.length) {
+            return;
+        }
+        const currEditor = vscode.window.activeTextEditor;
+        if (!currEditor) {
+            return;
+        }
+        const currBuf = this.uriToBuffer.get(currEditor.document.uri.toString());
+        if (!currBuf) {
+            return;
+        }
+        const eol = currEditor.document.eol === vscode.EndOfLine.LF ? "\n" : "\r\n";
+        const currWinId = this.editorColumnIdToWinId.get(currEditor.viewColumn || -1);
+        if (!currWinId) {
+            return;
+        }
+
+        // temporary buffer to replay the changes
+        const buf = await this.client.createBuffer(true, true);
+        if (typeof buf === "number") {
+            return;
+        }
+        // create temporary win
+        const win = await this.client.openWindow(buf, true, {
+            external: true,
+            width: NVIM_WIN_WIDTH,
+            height: NVIM_WIN_HEIGHT,
+        });
+        if (typeof win === "number") {
+            return;
+        }
+        const edits: [string, unknown[]][] = [];
+
+        // for delete changes we need an actual text, so let's prefill with something
+        // accumulate all possible lengths of deleted text to be safe
+        const delRangeLength = this.lastChanges.reduce((total, change) => {
+            return total + change.rangeLength;
+        }, 0);
+        if (delRangeLength) {
+            const stub = new Array(delRangeLength).fill("x").join("");
+            edits.push(["nvim_buf_set_lines", [buf.id, 0, 0, false, [stub]]]);
+        }
+        if (delRangeLength) {
+            edits.push(["nvim_win_set_cursor", [win.id, [1, delRangeLength]]]);
+        }
+        let editStr = "";
+        for (const change of this.lastChanges) {
+            if (change.rangeLength) {
+                editStr += [...new Array(change.rangeLength).keys()].map(() => "<BS>").join("");
+            }
+            editStr += change.text
+                .split(eol)
+                .join("\n")
+                .replace("<", "<LT>");
+        }
+        edits.push(["nvim_input", [editStr]]);
+        // since nvim_input is not blocking we need replay edits first, then clean up things in subsequent request
+        await this.client.callAtomic(edits);
+
+        const cleanEdits: [string, unknown[]][] = [];
+        cleanEdits.push(["nvim_set_current_win", [currWinId]]);
+        cleanEdits.push(["nvim_win_close", [win.id, true]]);
+        cleanEdits.push(["nvim_command", [`bwipeout! ${buf.id}`]]);
+        await this.client.callAtomic(cleanEdits);
+    };
+
     private uploadDocumentChangesToNeovim = async (): Promise<void> => {
         const requests: [string, unknown[]][] = [];
         for (const [uri, changed] of this.documentChangesInInsertMode) {
@@ -2209,10 +2306,13 @@ export class NVIMPluginController implements vscode.Disposable {
         if (!this.isInit) {
             return;
         }
+        // need <Esc> first otherwise it won't allow to switch the buffer
         if (this.isInsertMode) {
             this.leaveMultipleCursorsForVisualMode = false;
             await this.uploadDocumentChangesToNeovim();
+            await this.syncLastChangesWithDotRepeat();
         }
+        this.lastChanges = [];
         await this.client.input("<Esc>");
         // const buf = await this.client.buffer;
         // const lines = await buf.lines;

--- a/src/test/suite/dot-repeat.test.ts
+++ b/src/test/suite/dot-repeat.test.ts
@@ -1,0 +1,235 @@
+import vscode from "vscode";
+import { NeovimClient } from "neovim";
+
+import {
+    attachTestNvimClient,
+    closeNvimClient,
+    closeAllActiveEditors,
+    wait,
+    sendVSCodeKeys,
+    sendEscapeKey,
+    assertContent,
+    sendVSCodeSpecialKey,
+    pasteVSCode,
+    setSelection,
+    copyVSCodeSelection,
+} from "../utils";
+
+describe("Dot-repeat", () => {
+    let client: NeovimClient;
+    before(async () => {
+        client = await attachTestNvimClient();
+    });
+    after(async () => {
+        await closeNvimClient(client);
+    });
+
+    afterEach(async () => {
+        await closeAllActiveEditors();
+    });
+
+    it("Adding - simple", async () => {
+        const doc = await vscode.workspace.openTextDocument({
+            content: "abc",
+        });
+
+        await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
+        await wait(1000);
+
+        await sendVSCodeKeys("I");
+        await sendVSCodeKeys("123");
+        await sendEscapeKey();
+
+        await sendVSCodeKeys(".");
+        await assertContent(
+            {
+                content: ["123123abc"],
+            },
+            client,
+        );
+    });
+
+    it("Adding - with newline", async () => {
+        const doc = await vscode.workspace.openTextDocument({
+            content: "abc",
+        });
+
+        await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
+        await wait(1000);
+
+        await sendVSCodeKeys("A");
+        await sendVSCodeKeys("12\n3");
+        await sendEscapeKey();
+        await sendVSCodeKeys(".");
+
+        await assertContent(
+            {
+                content: ["abc12", "312", "3"],
+            },
+            client,
+        );
+    });
+
+    it("Adding - after newline", async () => {
+        const doc = await vscode.workspace.openTextDocument({
+            content: "abc",
+        });
+
+        await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
+        await wait(1000);
+
+        await sendVSCodeKeys("A");
+        await sendVSCodeKeys("\n123");
+        await sendEscapeKey();
+        await sendVSCodeKeys(".");
+
+        await assertContent(
+            {
+                content: ["abc", "123", "123"],
+            },
+            client,
+        );
+    });
+
+    it("Adding and deleting", async () => {
+        const doc = await vscode.workspace.openTextDocument({
+            content: "abc",
+        });
+
+        await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
+        await wait(1000);
+
+        await sendVSCodeKeys("A");
+        await sendVSCodeKeys("123");
+        await sendVSCodeSpecialKey("backspace");
+        await sendVSCodeSpecialKey("backspace");
+        await sendEscapeKey();
+        await sendVSCodeKeys(".");
+
+        await assertContent(
+            {
+                content: ["abc11"],
+            },
+            client,
+        );
+    });
+
+    it("Deleting", async () => {
+        const doc = await vscode.workspace.openTextDocument({
+            content: "abcabc",
+        });
+
+        await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
+        await wait(1000);
+
+        await sendVSCodeKeys("A");
+        await sendVSCodeSpecialKey("backspace");
+        await sendVSCodeSpecialKey("backspace");
+        await sendEscapeKey();
+        await sendVSCodeKeys(".");
+
+        await assertContent(
+            {
+                content: ["ab"],
+            },
+            client,
+        );
+    });
+
+    it("Deleting - full change", async () => {
+        const doc = await vscode.workspace.openTextDocument({
+            content: "abc",
+        });
+
+        await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
+        await wait(1000);
+
+        await sendVSCodeKeys("A");
+        await sendVSCodeKeys("123");
+        await sendVSCodeSpecialKey("backspace");
+        await sendVSCodeSpecialKey("backspace");
+        await sendVSCodeSpecialKey("backspace");
+        await sendEscapeKey();
+        await sendVSCodeKeys(".");
+
+        await assertContent(
+            {
+                content: ["abc"],
+            },
+            client,
+        );
+    });
+
+    it("Deleting - with newline", async () => {
+        const doc = await vscode.workspace.openTextDocument({
+            content: ["1abc", "2abc", "3abc"].join("\n"),
+        });
+
+        await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
+        await wait(1000);
+
+        await sendVSCodeKeys("jjli");
+        await sendVSCodeSpecialKey("backspace");
+        await sendVSCodeSpecialKey("backspace");
+        await sendVSCodeSpecialKey("backspace");
+        await sendEscapeKey();
+        await sendVSCodeKeys(".");
+
+        await assertContent(
+            {
+                content: ["1abcbabc"],
+            },
+            client,
+        );
+    });
+
+    it("Paste", async () => {
+        const doc = await vscode.workspace.openTextDocument({
+            content: "abc",
+        });
+
+        await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
+        await wait(1000);
+        await sendVSCodeKeys("I");
+        await setSelection([{ anchorPos: [0, 0], cursorPos: [0, 3] }]);
+        await copyVSCodeSelection();
+
+        await setSelection([{ anchorPos: [0, 3], cursorPos: [0, 3] }]);
+        await pasteVSCode();
+        await sendVSCodeSpecialKey("backspace");
+        await sendEscapeKey();
+        await sendVSCodeKeys(".");
+
+        await assertContent(
+            {
+                content: ["ababcab"],
+            },
+            client,
+        );
+    });
+
+    it("Multiline paste", async () => {
+        const doc = await vscode.workspace.openTextDocument({
+            content: ["1abc", "2abc"].join("\n"),
+        });
+
+        await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
+        await wait(1000);
+        await sendVSCodeKeys("I");
+        await setSelection([{ anchorPos: [0, 0], cursorPos: [1, 4] }]);
+        await copyVSCodeSelection();
+
+        await setSelection([{ anchorPos: [1, 4], cursorPos: [1, 4] }]);
+        await pasteVSCode();
+        await sendVSCodeSpecialKey("backspace");
+        await sendEscapeKey();
+        await sendVSCodeKeys(".");
+
+        await assertContent(
+            {
+                content: ["1abc", "2abc1abc", "1abc", "2ab2ab"],
+            },
+            client,
+        );
+    });
+});

--- a/vim/vscode-options.vim
+++ b/vim/vscode-options.vim
@@ -43,4 +43,4 @@ set modelines=0
 
 " Turn off auto-folding
 set nofoldenable
-set foldmethod='manual'
+set foldmethod=manual


### PR DESCRIPTION
This one is better than PR in #160 

This is utilizing the fact that `.` command repeats last stuff globally across all buffers & windows. So we tricking neovim by creating separate window & buffer and replaying last subsequent changes here by using `nvim_input` after exiting insert mode. After that this temporary buffer is being destroyed

Fixes #76 