### PR TITLE
Fix lag when cycling through command history

### DIFF
--- a/src/command_line.ts
+++ b/src/command_line.ts
@@ -214,6 +214,7 @@ export class CommandLineController implements Disposable {
         const res = await this.neovimClient.callFunction("getcmdline", []);
         if (res) {
             this.input.value = res;
+            this.input.show();
         }
     };
 
@@ -222,6 +223,7 @@ export class CommandLineController implements Disposable {
         const res = await this.neovimClient.callFunction("getcmdline", []);
         if (res) {
             this.input.value = res;
+            this.input.show();
         }
     };
 }


### PR DESCRIPTION
When in command line mode, pressing up and down to go through history
would lag enough to make it annoying when pressing up or down multiple
times quickly. Calling show() on the QuickPick after setting the new value
fixes this.