### PR TITLE
Dot-repeat and u are messed up with inInsertMode

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -888,7 +888,6 @@ export class NVIMPluginController implements vscode.Disposable {
         }
         if (!this.isInsertMode || this.isRecording) {
             this.client.input(this.normalizeKey(type.text));
-           // this.client.input(this.normalizeKey("i" + JSON.stringify(type.text)));
         } else {
             vscode.commands.executeCommand("default:type", { text: type.text });
         }
@@ -1655,21 +1654,6 @@ export class NVIMPluginController implements vscode.Disposable {
     };
 
     private handleModeChange = (modeName: string): void => {
-        // this.isInsertMode = modeName === "insert";
-        // if (this.isInsertMode && this.typeHandlerDisplose && !this.isRecording) {
-        //     this.typeHandlerDisplose.dispose();
-        //     this.typeHandlerDisplose = undefined;
-        // } else if (!this.isInsertMode && !this.typeHandlerDisplose) {
-        //     this.typeHandlerDisplose = vscode.commands.registerTextEditorCommand("type", this.onVSCodeType);
-        // }
-        // if (this.isRecording) {
-        //     if (modeName === "insert") {
-        //         vscode.commands.executeCommand("setContext", "neovim.recording", true);
-        //     } else {
-        //         this.isRecording = false;
-        //         vscode.commands.executeCommand("setContext", "neovim.recording", false);
-        //     }
-        // }
         this.currentModeName = modeName;
         const e = vscode.window.activeTextEditor;
         if (!e) {

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -1654,6 +1654,14 @@ export class NVIMPluginController implements vscode.Disposable {
     };
 
     private handleModeChange = (modeName: string): void => {
+        if (this.isRecording) {
+            if (modeName === "insert") {
+                vscode.commands.executeCommand("setContext", "neovim.recording", true);
+            } else {
+                this.isRecording = false;
+                vscode.commands.executeCommand("setContext", "neovim.recording", false);
+            }
+        }
         this.currentModeName = modeName;
         const e = vscode.window.activeTextEditor;
         if (!e) {

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -83,7 +83,7 @@ export class NVIMPluginController implements vscode.Disposable {
     private FIRST_SCREEN_LINE = 0;
     private LAST_SCREEN_LINE = 200;
 
-    private isInsertMode = false;
+    private readonly isInsertMode = false;
     private isRecording = false;
     /**
      * Current vim mode
@@ -888,6 +888,7 @@ export class NVIMPluginController implements vscode.Disposable {
         }
         if (!this.isInsertMode || this.isRecording) {
             this.client.input(this.normalizeKey(type.text));
+           // this.client.input(this.normalizeKey("i" + JSON.stringify(type.text)));
         } else {
             vscode.commands.executeCommand("default:type", { text: type.text });
         }
@@ -1654,21 +1655,21 @@ export class NVIMPluginController implements vscode.Disposable {
     };
 
     private handleModeChange = (modeName: string): void => {
-        this.isInsertMode = modeName === "insert";
-        if (this.isInsertMode && this.typeHandlerDisplose && !this.isRecording) {
-            this.typeHandlerDisplose.dispose();
-            this.typeHandlerDisplose = undefined;
-        } else if (!this.isInsertMode && !this.typeHandlerDisplose) {
-            this.typeHandlerDisplose = vscode.commands.registerTextEditorCommand("type", this.onVSCodeType);
-        }
-        if (this.isRecording) {
-            if (modeName === "insert") {
-                vscode.commands.executeCommand("setContext", "neovim.recording", true);
-            } else {
-                this.isRecording = false;
-                vscode.commands.executeCommand("setContext", "neovim.recording", false);
-            }
-        }
+        // this.isInsertMode = modeName === "insert";
+        // if (this.isInsertMode && this.typeHandlerDisplose && !this.isRecording) {
+        //     this.typeHandlerDisplose.dispose();
+        //     this.typeHandlerDisplose = undefined;
+        // } else if (!this.isInsertMode && !this.typeHandlerDisplose) {
+        //     this.typeHandlerDisplose = vscode.commands.registerTextEditorCommand("type", this.onVSCodeType);
+        // }
+        // if (this.isRecording) {
+        //     if (modeName === "insert") {
+        //         vscode.commands.executeCommand("setContext", "neovim.recording", true);
+        //     } else {
+        //         this.isRecording = false;
+        //         vscode.commands.executeCommand("setContext", "neovim.recording", false);
+        //     }
+        // }
         this.currentModeName = modeName;
         const e = vscode.window.activeTextEditor;
         if (!e) {


### PR DESCRIPTION
Greetings,

I was just experimenting with disabling all the things that the extension does to handle insert mode, and pass everything directly to neovim.  `c` commands, `i`, etc.,  now all work much better and dot-repeat seems to be more civilized.  

I'll be test running these changes for a few days to see what breaks in my day-to-day usage.  No need to merge as of yet.  Thanks!