### PR TITLE
Escape keys should only work in editorTextFocus mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ for `jj`
     {
         "command": "vscode-neovim.compositeEscape1",
         "key": "j",
-        "when": "neovim.mode == insert",
+        "when": "neovim.mode == insert && editorTextFocus",
         "args": "j"
     }
 ```
@@ -88,7 +88,7 @@ to enable `jk` add also:
     {
         "command": "vscode-neovim.compositeEscape2",
         "key": "k",
-        "when": "neovim.mode == insert",
+        "when": "neovim.mode == insert && editorTextFocus",
         "args": "k"
     }
 ```


### PR DESCRIPTION
In reference to https://github.com/asvetliakov/vscode-neovim/issues/290