### PR TITLE
fix: cursor is left behind

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,11 @@
                     "default": false,
                     "markdownDescription": "Use neovim installed in WSL. If you enable this setting, specify the path to the neovim executable installed in WSL `neovimExecutablePaths.linux` setting"
                 },
+                "vscode-neovim.revealCursorScrollLine": {
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "If 'true' reveals the cursor when scrolling by line and if it is outside view port"
+                },
                 "vscode-neovim.logPath": {
                     "type": "string",
                     "default": "",

--- a/src/commands_controller.ts
+++ b/src/commands_controller.ts
@@ -2,6 +2,7 @@ import vscode, { Disposable } from "vscode";
 import { NeovimClient } from "neovim";
 
 import { NeovimExtensionRequestProcessable } from "./neovim_events_processable";
+import { EXT_NAME } from "./utils";
 
 export class CommandsController implements Disposable, NeovimExtensionRequestProcessable {
     private client: NeovimClient;
@@ -108,7 +109,9 @@ export class CommandsController implements Disposable, NeovimExtensionRequestPro
     };
 
     private scrollLine = (to: "up" | "down"): void => {
-        vscode.commands.executeCommand("editorScroll", { to, by: "line", revealCursor: false });
+        const settings = vscode.workspace.getConfiguration(EXT_NAME);
+        const revealCursorScrollLine = settings.get("revealCursorScrollLine");
+        vscode.commands.executeCommand("editorScroll", { to, by: "line", revealCursor: revealCursorScrollLine });
     };
 
     private goToLine = (to: "top" | "middle" | "bottom"): void => {

--- a/src/commands_controller.ts
+++ b/src/commands_controller.ts
@@ -2,7 +2,6 @@ import vscode, { Disposable } from "vscode";
 import { NeovimClient } from "neovim";
 
 import { NeovimExtensionRequestProcessable } from "./neovim_events_processable";
-import { EXT_NAME } from "./utils";
 
 export class CommandsController implements Disposable, NeovimExtensionRequestProcessable {
     private client: NeovimClient;

--- a/src/commands_controller.ts
+++ b/src/commands_controller.ts
@@ -9,8 +9,11 @@ export class CommandsController implements Disposable, NeovimExtensionRequestPro
 
     private disposables: Disposable[] = [];
 
-    public constructor(client: NeovimClient) {
+    private revealCursorScrollLine: boolean;
+
+    public constructor(client: NeovimClient, revealCursorScrollLine: boolean) {
         this.client = client;
+        this.revealCursorScrollLine = revealCursorScrollLine;
 
         this.disposables.push(vscode.commands.registerCommand("vscode-neovim.ctrl-a-insert", this.ctrlAInsert));
         this.disposables.push(vscode.commands.registerCommand("vscode-neovim.send", (key) => this.sendToVim(key)));
@@ -109,9 +112,7 @@ export class CommandsController implements Disposable, NeovimExtensionRequestPro
     };
 
     private scrollLine = (to: "up" | "down"): void => {
-        const settings = vscode.workspace.getConfiguration(EXT_NAME);
-        const revealCursorScrollLine = settings.get("revealCursorScrollLine");
-        vscode.commands.executeCommand("editorScroll", { to, by: "line", revealCursor: revealCursorScrollLine });
+        vscode.commands.executeCommand("editorScroll", { to, by: "line", revealCursor: this.revealCursorScrollLine });
     };
 
     private goToLine = (to: "top" | "middle" | "bottom"): void => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,6 +20,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     const useCtrlKeysNormalMode = settings.get("useCtrlKeysForNormalMode", true);
     const useCtrlKeysInsertMode = settings.get("useCtrlKeysForInsertMode", true);
     const useWsl = settings.get("useWSL", false);
+    const revealCursorScrollLine = settings.get("revealCursorScrollLine", false);
     const neovimWidth = settings.get("neovimWidth", 1000);
     const customInit = getNeovimInitPath() ?? "";
     const logPath = settings.get("logPath", "");
@@ -44,6 +45,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             neovimViewportHeight: 201,
             useWsl: ext.extensionKind === vscode.ExtensionKind.Workspace ? false : useWsl,
             neovimViewportWidth: neovimWidth,
+            revealCursorScrollLine: revealCursorScrollLine,
             logConf: {
                 logPath,
                 outputToConsole,

--- a/src/main_controller.ts
+++ b/src/main_controller.ts
@@ -174,21 +174,6 @@ export class MainController implements vscode.Disposable {
         const channel = await this.client.channelId;
         await this.client.setVar("vscode_channel", channel);
 
-        this.logger.debug(`${LOG_PREFIX}: UIAttach`);
-        await this.client.uiAttach(this.NEOVIM_WIN_WIDTH, this.NEOVIM_WIN_HEIGHT, {
-            rgb: true,
-            // override: true,
-            ext_cmdline: true,
-            ext_linegrid: true,
-            ext_hlstate: true,
-            ext_messages: true,
-            ext_multigrid: true,
-            ext_popupmenu: true,
-            ext_tabline: true,
-            ext_wildmenu: true,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } as any);
-
         this.commandsController = new CommandsController(this.client, this.settings.revealCursorScrollLine);
         this.disposables.push(this.commandsController);
 

--- a/src/main_controller.ts
+++ b/src/main_controller.ts
@@ -40,6 +40,7 @@ export interface ControllerSettings {
     customInitFile: string;
     neovimViewportWidth: number;
     neovimViewportHeight: number;
+    revealCursorScrollLine: boolean;
     logConf: {
         level: "none" | "error" | "warn" | "debug";
         logPath: string;
@@ -174,7 +175,7 @@ export class MainController implements vscode.Disposable {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } as any);
 
-        this.commandsController = new CommandsController(this.client);
+        this.commandsController = new CommandsController(this.client, this.settings.revealCursorScrollLine);
         this.disposables.push(this.commandsController);
 
         this.modeManager = new ModeManager(this.logger);


### PR DESCRIPTION
https://stackoverflow.com/questions/49997089/vscode-how-to-set-that-when-i-press-ctrl-up-or-down-arrow-the-cursor-move-wi
Vs Code, by default, doesn't update cursor position after scrolling, which is not the case in vim. This pr makes experience more similar to scrolling in vim.