### PR TITLE
Use case-sensetive comparsion

### DIFF
--- a/vim/vscode-code-actions.vim
+++ b/vim/vscode-code-actions.vim
@@ -42,7 +42,7 @@ endfunction
 function! s:openVSCodeCommandsInVisualMode()
     normal! gv
     let visualmode = visualmode()
-    if visualmode == "V"
+    if visualmode ==# "V"
         let startLine = line("v")
         let endLine = line(".")
         call VSCodeNotifyRange("workbench.action.showCommands", startLine, endLine, 1)

--- a/vim/vscode-file-commands.vim
+++ b/vim/vscode-file-commands.vim
@@ -3,15 +3,15 @@ function! s:editOrNew(...)
     let file = a:1
     let bang = a:2
 
-    if file == ''
-        if bang == '!'
+    if empty(file)
+        if bang ==# '!'
             call VSCodeNotify('workbench.action.files.openFile')
         else
             call VSCodeNotify('workbench.action.quickOpen')
         endif
     else
         " Last arg is to close previous file, e.g. e! ~/blah.txt will open blah.txt instead the current file
-        call VSCodeExtensionNotify('open-file', expand(file), bang == '!' ? 1 : 0)
+        call VSCodeExtensionNotify('open-file', expand(file), bang ==# '!' ? 1 : 0)
     endif
 endfunction
 
@@ -31,11 +31,11 @@ command! -bang -nargs=? Ex call <SID>editOrNew(<q-args>, <q-bang>)
 command! -bang Enew call <SID>editOrNew('__vscode_new__', <q-bang>)
 command! -bang Find call VSCodeNotify('workbench.action.quickOpen')
 
-command! -complete=file -bang Write if <q-bang> == '!' | call VSCodeNotify('workbench.action.files.saveAs') | else | call VSCodeNotify('workbench.action.files.save') | endif
+command! -complete=file -bang Write if <q-bang> ==# '!' | call VSCodeNotify('workbench.action.files.saveAs') | else | call VSCodeNotify('workbench.action.files.save') | endif
 command! -bang Saveas call VSCodeNotify('workbench.action.files.saveAs')
 
 command! -bang Wall call VSCodeNotify('workbench.action.files.saveAll')
-command! -bang Quit if <q-bang> == '!' | call VSCodeNotify('workbench.action.revertAndCloseActiveEditor') | else | call VSCodeNotify('workbench.action.closeActiveEditor') | endif
+command! -bang Quit if <q-bang> ==# '!' | call VSCodeNotify('workbench.action.revertAndCloseActiveEditor') | else | call VSCodeNotify('workbench.action.closeActiveEditor') | endif
 
 command! -bang Wq call <SID>saveAndClose()
 

--- a/vim/vscode-insert.vim
+++ b/vim/vscode-insert.vim
@@ -9,7 +9,7 @@ endfunction
 
 function! s:vscodeMultipleCursorsVisualMode(append, skipEmpty)
     let m = visualmode()
-    if m == "V" || m == "\<C-v>"
+    if m ==# "V" || m ==# "\<C-v>"
         startinsert
         call VSCodeExtensionNotify('visual-edit', a:append, m, line("'<"), line("'>"), a:skipEmpty)
     endif

--- a/vim/vscode-tab-commands.vim
+++ b/vim/vscode-tab-commands.vim
@@ -2,16 +2,16 @@ function! s:switchEditor(...) abort
     let count = a:1
     let direction = a:2
     for i in range(1, count ? count : 1)
-        call VSCodeCall(direction == 'next' ? 'workbench.action.nextEditorInGroup' : 'workbench.action.previousEditorInGroup')
+        call VSCodeCall(direction ==# 'next' ? 'workbench.action.nextEditorInGroup' : 'workbench.action.previousEditorInGroup')
     endfor
 endfunction
 
-command! -complete=file -nargs=? Tabedit if <q-args> == '' | call VSCodeNotify('workbench.action.quickOpen') | else | call VSCodeExtensionNotify('open-file', expand(<q-args>), 0) | endif
+command! -complete=file -nargs=? Tabedit if empty(<q-args>) | call VSCodeNotify('workbench.action.quickOpen') | else | call VSCodeExtensionNotify('open-file', expand(<q-args>), 0) | endif
 command! -complete=file Tabnew call VSCodeExtensionNotify('open-file', '__vscode_new__', 0)
 command! Tabfind call VSCodeNotify('workbench.action.quickOpen')
 command! Tab echoerr 'Not supported'
 command! Tabs echoerr 'Not supported'
-command! -bang Tabclose if <q-bang> == '!' | call VSCodeNotify('workbench.action.revertAndCloseActiveEditor') | else | call VSCodeNotify('workbench.action.closeActiveEditor') | endif
+command! -bang Tabclose if <q-bang> ==# '!' | call VSCodeNotify('workbench.action.revertAndCloseActiveEditor') | else | call VSCodeNotify('workbench.action.closeActiveEditor') | endif
 command! Tabonly call VSCodeNotify('workbench.action.closeOtherEditors')
 command! -nargs=? Tabnext call <SID>switchEditor(<q-args>, 'next')
 command! -nargs=? Tabprevious call <SID>switchEditor(<q-args>, 'prev')

--- a/vim/vscode-window-commands.vim
+++ b/vim/vscode-window-commands.vim
@@ -2,7 +2,7 @@
 function! s:split(...) abort
     let direction = a:1
     let file = a:2
-    call VSCodeCall(direction == 'h' ? 'workbench.action.splitEditorDown' : 'workbench.action.splitEditorRight')
+    call VSCodeCall(direction ==# 'h' ? 'workbench.action.splitEditorDown' : 'workbench.action.splitEditorRight')
     if file != ''
         call VSCodeExtensionNotify('open-file', expand(file), 'all')
     endif
@@ -10,7 +10,7 @@ endfunction
 
 function! s:splitNew(...)
     let file = a:2
-    call s:split(a:1, file == '' ? '__vscode_new__' : file)
+    call s:split(a:1, empty(file) ? '__vscode_new__' : file)
 endfunction
 
 function! s:closeOtherEditors()
@@ -22,7 +22,7 @@ function! s:manageEditorSize(...)
     let count = a:1
     let to = a:2
     for i in range(1, count ? count : 1)
-        call VSCodeNotify(to == 'increase' ? 'workbench.action.increaseViewSize' : 'workbench.action.decreaseViewSize')
+        call VSCodeNotify(to ==# 'increase' ? 'workbench.action.increaseViewSize' : 'workbench.action.decreaseViewSize')
     endfor
 endfunction
 
@@ -30,7 +30,7 @@ command! -complete=file -nargs=? Split call <SID>split('h', <q-args>)
 command! -complete=file -nargs=? Vsplit call <SID>split('v', <q-args>)
 command! -complete=file -nargs=? New call <SID>split('h', '__vscode_new__')
 command! -complete=file -nargs=? Vnew call <SID>split('v', '__vscode_new__')
-command! -bang Only if <q-bang> == '!' | call <SID>closeOtherEditors() | else | call VSCodeNotify('workbench.action.joinAllGroups') | endif
+command! -bang Only if <q-bang> ==# '!' | call <SID>closeOtherEditors() | else | call VSCodeNotify('workbench.action.joinAllGroups') | endif
 
 AlterCommand sp[lit] Split
 AlterCommand vs[plit] Vsplit


### PR DESCRIPTION
Vimscript uses settings-dependent case comparsion by default. Use case-sensetive comparsion to avoid issues caused by `set ignorecase`. Closes #308.