### PR TITLE
Fix dot repeat problems

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -221,6 +221,8 @@ export class NVIMPluginController implements vscode.Disposable {
 
     /**
      * Special variable to hint dot repeat if the insert mode was started through o or O
+     * Note: vscode doesn't tell if a change was originated through a command (such as insertLineBefore/After) or through a keystroke (e.g. Enter),
+     * And we're using vscode version of o/O because of indent (VIM shouldn't know about syntax/indent), so need an internal state
      */
     private dotRepeatInsertModeStartHint?: "o" | "O";
 

--- a/src/test/suite/dot-repeat.test.ts
+++ b/src/test/suite/dot-repeat.test.ts
@@ -268,4 +268,25 @@ describe("Dot-repeat", () => {
             client,
         );
     });
+
+    it("inew word inside line", async () => {
+        const doc = await vscode.workspace.openTextDocument({
+            content: ["test1", "test2"].join("\n"),
+        });
+        await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
+        await wait(1000);
+
+        await sendVSCodeKeys("gg0ll");
+        await sendVSCodeKeys("inew word");
+        await sendEscapeKey();
+        await sendVSCodeKeys("0jll");
+
+        await sendVSCodeKeys(".");
+        await assertContent(
+            {
+                content: ["tenew wordst1", "tenew wordst2"],
+            },
+            client,
+        );
+    });
 });

--- a/src/test/suite/dot-repeat.test.ts
+++ b/src/test/suite/dot-repeat.test.ts
@@ -232,4 +232,40 @@ describe("Dot-repeat", () => {
             client,
         );
     });
+
+    it("O and o", async () => {
+        const doc = await vscode.workspace.openTextDocument({
+            content: ["test1", "test2", "test3"].join("\n"),
+        });
+        await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
+        await wait(1000);
+        await sendVSCodeKeys("jl");
+        await sendVSCodeKeys("o");
+        await sendVSCodeKeys("blah");
+        await sendEscapeKey();
+
+        // reset cursor to 0.0
+        await sendVSCodeKeys("0ggll");
+        await sendVSCodeKeys(".");
+
+        await assertContent(
+            {
+                content: ["test1", "blah", "test2", "blah", "test3"],
+            },
+            client,
+        );
+
+        await sendVSCodeKeys("0ggjO");
+        await sendVSCodeKeys("blah2");
+        await sendEscapeKey();
+
+        await sendVSCodeKeys("0ggll");
+        await sendVSCodeKeys(".");
+        await assertContent(
+            {
+                content: ["blah2", "test1", "blah2", "blah", "test2", "blah", "test3"],
+            },
+            client,
+        );
+    });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,6 +25,28 @@ export interface GridConf {
 
 export type GridLineEvent = [number, number, number, [string, number, number][]];
 
+/**
+ * Simplified vscode.TextDocumentChangeEvent with start mode hint additions
+ */
+export interface DotRepeatChange {
+    /**
+     * Num of deleted characters, 0 when only added
+     */
+    rangeLength: number;
+    /**
+     * Stored range offset
+     */
+    rangeOffset: number;
+    /**
+     * New text. May contin new line
+     */
+    text: string;
+    /**
+     * Set if it was the first change and started either through o or O
+     */
+    startMode?: "o" | "O";
+}
+
 export function processLineNumberStringFromEvent(
     event: GridLineEvent,
     lineNumberHlId: number,
@@ -292,7 +314,7 @@ export function getEditorCursorPos(editor: TextEditor, conf: GridConf): { line: 
 
 export function isChangeSubsequentToChange(
     change: TextDocumentContentChangeEvent,
-    lastChange: TextDocumentContentChangeEvent,
+    lastChange: DotRepeatChange,
 ): boolean {
     const lastChangeTextLength = lastChange.text.length;
     const lastChangeOffsetStart = lastChange.rangeOffset;
@@ -378,4 +400,16 @@ export function getNeovimInitPath(): string | undefined {
         vscodeSettingName: "neovimInitPath",
     } as const;
     return getSystemSpecificSetting("neovimInitVimPaths", legacySettingInfo);
+}
+
+export function normalizeDotRepeatChange(
+    change: TextDocumentContentChangeEvent,
+    startMode?: "o" | "O",
+): DotRepeatChange {
+    return {
+        rangeLength: change.rangeLength,
+        rangeOffset: change.rangeOffset,
+        text: change.text,
+        startMode,
+    };
 }

--- a/vim/vscode-insert.vim
+++ b/vim/vscode-insert.vim
@@ -18,6 +18,10 @@ endfunction
 nnoremap <silent> O :<C-u> call<SID>vscodeInsertBefore()<CR>
 nnoremap <silent> o :<C-u> call<SID>vscodeInsertAfter()<CR>
 
+" For calling original vim o/O, used for dot-repeat
+nnoremap <silent> mO O
+nnoremap <silent> mo o
+
 " Multiple cursors support for visual line/block modes
 xnoremap <silent> ma :<C-u>call <SID>vscodeMultipleCursorsVisualMode(1, 1)<CR>
 xnoremap <silent> mi :<C-u>call <SID>vscodeMultipleCursorsVisualMode(0, 1)<CR>


### PR DESCRIPTION
Fixes o/O problem with dot-repeat

>Repeating the edit of oword acts like a paste of a new line and the word wherever your cursor is.

Added test for this case:

>Repeating the edit of inew word would sometimes work and sometimes only insert the last part of it. I think it was the space and the second word, but I couldn't get it consistent.

>Repeating the edit of A (2)

Autoclosed brackets are really hard since vscode is adding matched bracket in single edit, then moves the cursor thus breaking the repeat sequence. Possible solution is to break the bracket edit to 2 edits then try to keep the closing bracket as last change

refs #209 