### PR TITLE
Set default Linux path

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,9 +57,9 @@
 				},
 				"vscode-neovim.neovimExecutablePaths.linux": {
 					"type": "string",
-					"default": "",
+					"default": "/usr/bin/nvim",
 					"title": "Neovim executable path on Linux (and in WSL)",
-					"markdownDescription": "Full path to Neovim executable that should be used by the extension if running VS Code on Linux or WSL. If `useWSL` setting is checked, vscode-neovim will look for this path in WSL  \nExample:  \n/usr/bin/nvim"
+					"markdownDescription": "Full path to Neovim executable that should be used by the extension if running VS Code on Linux or WSL. If `useWSL` setting is checked, vscode-neovim will look for this path in WSL."
 				},
 				"vscode-neovim.neovimInitPath": {
 					"type": "string",


### PR DESCRIPTION
In this PR I set default Neovim path to `/usr/bin/nvim` for Linux. I think this can be reasonable default.