### PR TITLE
Store additional keystrokes to pending key queue

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -2340,7 +2340,9 @@ export class NVIMPluginController implements vscode.Disposable {
             this.isExitingInsertMode = true;
             // rebind early to store fast pressed keys which may happen between sending changes to neovim and exiting insert mode
             // see https://github.com/asvetliakov/vscode-neovim/issues/324
-            this.typeHandlerDisplose = vscode.commands.registerTextEditorCommand("type", this.onVSCodeType);
+            if (!this.typeHandlerDisplose) {
+                this.typeHandlerDisplose = vscode.commands.registerTextEditorCommand("type", this.onVSCodeType);
+            }
             this.leaveMultipleCursorsForVisualMode = false;
             await this.uploadDocumentChangesToNeovim();
             await this.syncLastChangesWithDotRepeat();

--- a/src/test/suite/insert-mode.test.ts
+++ b/src/test/suite/insert-mode.test.ts
@@ -437,4 +437,25 @@ describe("Insert mode and buffer syncronization", () => {
             client,
         );
     });
+
+    it("Handles keys typed immediately after sending escape key", async () => {
+        const doc = await vscode.workspace.openTextDocument({
+            content: ["blah1 blah2"].join("\n"),
+        });
+        await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
+        await wait();
+
+        await sendVSCodeKeys("ea");
+        await sendVSCodeKeys("aaa");
+
+        await Promise.all([sendEscapeKey(1000), sendVSCodeKeys("$")]);
+
+        await assertContent(
+            {
+                cursor: [0, 13],
+                content: ["blah1aaa blah2"],
+            },
+            client,
+        );
+    });
 });


### PR DESCRIPTION
1. Rebind type command early before sending changes to neovim
2. Store any pressed keys here
3. Send them with escape command

fixes #324  