### PR TITLE
Improve code actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,12 @@ Neovim 0.4.2 or greater
 -   It's possible to call vscode commands from neovim. See `VSCodeCall/VSCodeNotify` vim functions in `vscode-neovim.vim` file. `VSCodeCall` is blocking request, while `VSCodeNotify` is not (see below)
 -   Scrolling is done by VSCode side. `<C-d>/<C-u>/etc...` are slighly different
 -   File management commands such as `e` / `w` / `q` etc are mapped to corresponding vscode commands and behavior may be different (see below)
--   `gf`/`gd`/`<C-]` are mapped to `editor.action.revealDefinition` (Shortcut `F12`). also `<C-]>` works in vim helps files
--   `gF`/`gD` are mapped to `editor.action.peekDefinition` (opens definition in peek)
--   `<C-w>gF`/`<C-w>gf`/`<C-w>gd` are mapped to `editor.action.revealDefinitionAside` (original vim command - open new tab and go to the file under cursor, but vscode/vim window/tabs metaphors are completely different, so it's useful to do slighlty different thing here)
+-   `gd`/`<C-]` are mapped to `editor.action.revealDefinition` (Shortcut `F12`), also `<C-]>` works in vim help files
+-   `gf` is mapped to `editor.action.revealDeclaration`
+-   `gH` is mapped to `editor.action.referenceSearch.trigger`
+-   `gD`/`gF` are mapped to `editor.action.peekDefinition` and `editor.action.peekDeclaration` respectively (opens in peek)
+-   `<C-w>gd`/`<C-w>gf` are mapped to `editor.action.revealDefinitionAside` and `editor.action.revealDeclarationAside` respectively (original vim command - open new tab and go to the file under cursor, but vscode/vim window/tabs metaphors are completely different, so it's useful to do slightly different thing here)
+-   `gh` is mapped to `editor.action.showHover`
 -   Dot-repeat (`.`) . Works starting from `0.0.52` version. Moving cursor within a change range won't break the repeat sequence. I.e. in neovim, if you type `abc<cursor>` in insert mode then move cursor to `a<cursor>bc` and type `1` here the repeat sequence would be `1`. However in vscode it would be `a1bc`. Another difference that `.` repeat command when you delete some text only works from right-to-left. I.e. it will treat `<Del>` key as `<BS>` keys for dot repeat.
 -   Outline navigation doesn't create jumpoints
 

--- a/vim/vscode-code-actions.vim
+++ b/vim/vscode-code-actions.vim
@@ -84,10 +84,8 @@ xnoremap <silent> gH :<C-u>call VSCodeNotify('editor.action.referenceSearch.trig
 " <C-w> gf opens definition on the side
 nnoremap <silent> <C-w>gf :<C-u>call VSCodeNotify('editor.action.revealDeclarationAside')<CR>
 nnoremap <silent> <C-w>gd :<C-u>call VSCodeNotify('editor.action.revealDefinitionAside')<CR>
-nnoremap <silent> <C-w>gF :<C-u>call VSCodeNotify('editor.action.revealDeclarationAside')<CR>
 xnoremap <silent> <C-w>gf :<C-u>call VSCodeNotify('editor.action.revealDeclarationAside')<CR>
 xnoremap <silent> <C-w>gd :<C-u>call VSCodeNotify('editor.action.revealDefinitionAside')<CR>
-xnoremap <silent> <C-w>gF :<C-u>call VSCodeNotify('editor.action.revealDeclarationAside')<CR>
 
 " Bind C-/ to vscode commentary since calling from vscode produces double comments due to multiple cursors
 xnoremap <expr> <C-/> <SID>vscodeCommentary()

--- a/vim/vscode-code-actions.vim
+++ b/vim/vscode-code-actions.vim
@@ -24,10 +24,10 @@ function! s:vscodeCommentary(...) abort
     call VSCodeCallRange("editor.action.commentLine", line1, line2, 0)
 endfunction
 
-function! s:vscodeGoToDefinition()
+function! s:vscodeGoToDefinition(str)
     if exists('b:vscode_controlled') && b:vscode_controlled
         exe "normal! m'"
-        call VSCodeNotify("editor.action.revealDefinition")
+        call VSCodeNotify("editor.action.reveal" . a:str)
     else
         " Allow to funcionar in help files
         exe "normal! \<C-]>"
@@ -65,26 +65,29 @@ nnoremap <expr> = <SID>vscodeFormat()
 nnoremap <expr> == <SID>vscodeFormat() . '_'
 
 " gf/gF . Map to go to definition for now
-nnoremap <silent> gf :<C-u>call <SID>vscodeGoToDefinition()<CR>
-nnoremap <silent> gd :<C-u>call <SID>vscodeGoToDefinition()<CR>
 nnoremap <silent> gh :<C-u>call VSCodeNotify('editor.action.showHover')<CR>
-nnoremap <silent> <C-]> :<C-u>call <SID>vscodeGoToDefinition()<CR>
-nnoremap <silent> gF :<C-u>call VSCodeNotify('editor.action.peekDefinition')<CR>
+nnoremap <silent> gf :<C-u>call <SID>vscodeGoToDefinition("Declaration")<CR>
+nnoremap <silent> gd :<C-u>call <SID>vscodeGoToDefinition("Definition")<CR>
+nnoremap <silent> <C-]> :<C-u>call <SID>vscodeGoToDefinition("Definition")<CR>
+nnoremap <silent> gF :<C-u>call VSCodeNotify('editor.action.peekDeclaration')<CR>
 nnoremap <silent> gD :<C-u>call VSCodeNotify('editor.action.peekDefinition')<CR>
+nnoremap <silent> gH :<C-u>call VSCodeNotify('editor.action.referenceSearch.trigger')<CR>
 
-xnoremap <silent> gf :<C-u>call <SID>vscodeGoToDefinition()<CR>
-xnoremap <silent> gd :<C-u>call <SID>vscodeGoToDefinition()<CR>
 xnoremap <silent> gh :<C-u>call <SID>hover()<CR>
-xnoremap <silent> <C-]> :<C-u>call <SID>vscodeGoToDefinition()<CR>
-xnoremap <silent> gF :<C-u>call VSCodeNotify('editor.action.peekDefinition')<CR>
+xnoremap <silent> gf :<C-u>call <SID>vscodeGoToDefinition("Declaration")<CR>
+xnoremap <silent> gd :<C-u>call <SID>vscodeGoToDefinition("Definition")<CR>
+xnoremap <silent> <C-]> :<C-u>call <SID>vscodeGoToDefinition("Definition")<CR>
+xnoremap <silent> gF :<C-u>call VSCodeNotify('editor.action.peekDeclaration')<CR>
 xnoremap <silent> gD :<C-u>call VSCodeNotify('editor.action.peekDefinition')<CR>
+xnoremap <silent> gH :<C-u>call VSCodeNotify('editor.action.referenceSearch.trigger')<CR>
+
 " <C-w> gf opens definition on the side
-nnoremap <silent> <C-w>gf :<C-u>call VSCodeNotify('editor.action.revealDefinitionAside')<CR>
+nnoremap <silent> <C-w>gf :<C-u>call VSCodeNotify('editor.action.revealDeclarationAside')<CR>
 nnoremap <silent> <C-w>gd :<C-u>call VSCodeNotify('editor.action.revealDefinitionAside')<CR>
-nnoremap <silent> <C-w>gF :<C-u>call VSCodeNotify('editor.action.revealDefinitionAside')<CR>
-xnoremap <silent> <C-w>gf :<C-u>call VSCodeNotify('editor.action.revealDefinitionAside')<CR>
+nnoremap <silent> <C-w>gF :<C-u>call VSCodeNotify('editor.action.revealDeclarationAside')<CR>
+xnoremap <silent> <C-w>gf :<C-u>call VSCodeNotify('editor.action.revealDeclarationAside')<CR>
 xnoremap <silent> <C-w>gd :<C-u>call VSCodeNotify('editor.action.revealDefinitionAside')<CR>
-xnoremap <silent> <C-w>gF :<C-u>call VSCodeNotify('editor.action.revealDefinitionAside')<CR>
+xnoremap <silent> <C-w>gF :<C-u>call VSCodeNotify('editor.action.revealDeclarationAside')<CR>
 
 " Bind C-/ to vscode commentary since calling from vscode produces double comments due to multiple cursors
 xnoremap <expr> <C-/> <SID>vscodeCommentary()


### PR DESCRIPTION
Having both gd and gf mapped to "revealDefinition" seemed redundant, so this PR maps gf to "revealDeclaration". In some languages like C++ this makes a difference, and the mnemonic "go to forward declaration" makes sense for gf. gd remains "go to definition".

I refactored the `vscodeGoToDefinition` function to support these two modes without needing to duplicate the function.

I also provided a binding for "revealReferences", and since "hover" is gh, I figured gH is a decent choice.

Finally, I'm not sure why `<C-w>gF` was mapped to the same thing as `<C-w>gf`, I know it was meant to mirror neovim but there are so many other missing keybindings that I don't think this little one is worth the space it takes.

With neovim now working inside peek, this functionality has suddenly become significantly more useful :grin: 