### PR TITLE
Fix possible deadlock

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
                 },
                 "vscode-neovim.logLevel": {
                     "type": "string",
-                    "default": "none",
+                    "default": "error",
                     "enum": [
                         "none",
                         "error",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,28 +29,32 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     vscode.commands.executeCommand("setContext", "neovim.ctrlKeysNormal", useCtrlKeysNormalMode);
     vscode.commands.executeCommand("setContext", "neovim.ctrlKeysInsert", useCtrlKeysInsertMode);
 
-    const plugin = new MainController({
-        customInitFile: customInit,
-        extensionPath: context.extensionPath,
-        highlightsConfiguration: {
-            highlights: highlightConfHighlights,
-            ignoreHighlights: highlightConfIgnore,
-            unknownHighlight: highlightConfUnknown,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } as any,
-        mouseSelection: mouseVisualSelection,
-        neovimPath: neovimPath,
-        neovimViewportHeight: 201,
-        useWsl: ext.extensionKind === vscode.ExtensionKind.Workspace ? false : useWsl,
-        neovimViewportWidth: neovimWidth,
-        logConf: {
-            logPath,
-            outputToConsole,
-            level: logLevel,
-        },
-    });
-    context.subscriptions.push(plugin);
-    await plugin.init();
+    try {
+        const plugin = new MainController({
+            customInitFile: customInit,
+            extensionPath: context.extensionPath,
+            highlightsConfiguration: {
+                highlights: highlightConfHighlights,
+                ignoreHighlights: highlightConfIgnore,
+                unknownHighlight: highlightConfUnknown,
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            } as any,
+            mouseSelection: mouseVisualSelection,
+            neovimPath: neovimPath,
+            neovimViewportHeight: 201,
+            useWsl: ext.extensionKind === vscode.ExtensionKind.Workspace ? false : useWsl,
+            neovimViewportWidth: neovimWidth,
+            logConf: {
+                logPath,
+                outputToConsole,
+                level: logLevel,
+            },
+        });
+        context.subscriptions.push(plugin);
+        await plugin.init();
+    } catch (e) {
+        vscode.window.showErrorMessage(`Unable to init vscode-neovim: ${e.message}`);
+    }
 }
 
 // this method is called when your extension is deactivated

--- a/src/main_controller.ts
+++ b/src/main_controller.ts
@@ -160,6 +160,14 @@ export class MainController implements vscode.Disposable {
 
     public async init(): Promise<void> {
         this.logger.debug(`${LOG_PREFIX}: Init`);
+
+        this.logger.debug(`${LOG_PREFIX}: Attaching to neovim notifications`);
+        this.client.on("disconnect", () => {
+            this.logger.error(`${LOG_PREFIX}: Neovim was disconnected`);
+        });
+        this.client.on("notification", this.onNeovimNotification);
+        this.client.on("request", this.handleCustomRequest);
+
         await this.client.setClientInfo("vscode-neovim", { major: 0, minor: 1, patch: 0 }, "embedder", {}, {});
         await this.checkNeovimVersion();
         const channel = await this.client.channelId;
@@ -212,13 +220,6 @@ export class MainController implements vscode.Disposable {
 
         this.multilineMessagesManager = new MutlilineMessagesManager(this.logger);
         this.disposables.push(this.multilineMessagesManager);
-
-        this.logger.debug(`${LOG_PREFIX}: Attaching to neovim notifications`);
-        this.client.on("disconnect", () => {
-            this.logger.error(`${LOG_PREFIX}: Neovim was disconnected`);
-        });
-        this.client.on("notification", this.onNeovimNotification);
-        this.client.on("request", this.handleCustomRequest);
 
         this.logger.debug(`${LOG_PREFIX}: UIAttach`);
         // !Attach after setup of notifications, otherwise we can get blocking call and stuck


### PR DESCRIPTION
Fixes #340 

`ui_attach` should be called after we bind request event handler. Otherwise neovim can request `VSCodeCall/VSCodeExtensionCall` before and stuck forever waiting for a response

Also make non-debounced version of sync layout methods and wait for them before completing `init()`