### PR TITLE
fix <C-w>w & <C-w><C-w>

### DIFF
--- a/vim/vscode-window-commands.vim
+++ b/vim/vscode-window-commands.vim
@@ -72,8 +72,8 @@ xnoremap <silent> <C-w>l :<C-u>call VSCodeNotify('workbench.action.focusRightGro
 nnoremap <silent> <C-w><C-l> :<C-u>call VSCodeNotify('workbench.action.moveEditorToRightGroup')<CR>
 xnoremap <silent> <C-w><C-l> :<C-u>call VSCodeNotify('workbench.action.moveEditorToRightGroup')<CR>
 nnoremap <silent> <C-w>w :<C-u>call VSCodeNotify('workbench.action.focusNextGroup')<CR>
-nnoremap <silent> <C-w>w :<C-u>call VSCodeNotify('workbench.action.focusNextGroup')<CR>
-xnoremap <silent> <C-w><C-w> :<C-u>call VSCodeNotify('workbench.action.focusNextGroup')<CR>
+xnoremap <silent> <C-w>w :<C-u>call VSCodeNotify('workbench.action.focusNextGroup')<CR>
+nnoremap <silent> <C-w><C-w> :<C-u>call VSCodeNotify('workbench.action.focusNextGroup')<CR>
 xnoremap <silent> <C-w><C-w> :<C-u>call VSCodeNotify('workbench.action.focusNextGroup')<CR>
 nnoremap <silent> <C-w>W :<C-u>call VSCodeNotify('workbench.action.focusPreviousGroup')<CR>
 xnoremap <silent> <C-w>W :<C-u>call VSCodeNotify('workbench.action.focusPreviousGroup')<CR>


### PR DESCRIPTION
I was wondering why `<C-w><C-w>` wasn't working in the extension and stumpled upon these duplicate definitions for `<C-w>w` & `<C-w><C-w>` for the same modes respectively.

This PR changes the definitions such that `<C-w>w` and `<C-w><C-w>` work in both normal and visual modes.