### PR TITLE
Refactor Vimscript

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,38 +128,36 @@ Produce linewise selection and show vscode commands (default binding)
 
 ```
 function! s:showCommands()
-    normal! gv
     let startLine = line("v")
     let endLine = line(".")
     call VSCodeNotifyRange("workbench.action.showCommands", startLine, endLine, 1)
 endfunction
 
-xnoremap <silent> <C-P> :<C-u>call <SID>showCommands()<CR>
+xnoremap <silent> <C-P> <Cmd>call <SID>showCommands()<CR>
 ```
 
 Produce characterwise selection and show vscode commands (default binding):
 
 ```
 function! s:showCommands()
-    normal! gv
     let startPos = getpos("v")
     let endPos = getpos(".")
     call VSCodeNotifyRangePos("workbench.action.showCommands", startPos[1], endPos[1], startPos[2], endPos[2], 1)
 endfunction
 
-xnoremap <silent> <C-P> :<C-u>call <SID>showCommands()<CR>
+xnoremap <silent> <C-P> <Cmd>call <SID>showCommands()<CR>
 ```
 
 Run Find in files for word under cursor in vscode:
 
 ```
-nnoremap <silent> ? :<C-u>call VSCodeNotify('workbench.action.findInFiles', { 'query': expand('<cword>')})<CR>
+nnoremap <silent> ? <Cmd>call VSCodeNotify('workbench.action.findInFiles', { 'query': expand('<cword>')})<CR>
 ```
 
 Open definition aside (default binding):
 
 ```
-nnoremap <silent> <C-w>gd :<C-u>call VSCodeNotify('editor.action.revealDefinitionAside')<CR>
+nnoremap <silent> <C-w>gd <Cmd>call VSCodeNotify('editor.action.revealDefinitionAside')<CR>
 ```
 
 ## Jumplist

--- a/vim/vscode-code-actions.vim
+++ b/vim/vscode-code-actions.vim
@@ -8,7 +8,7 @@ function! s:vscodeFormat(...) abort
         let [line1, line2] = [line("'["), line("']")]
     endif
 
-    call VSCodeCallRange("editor.action.formatSelection", line1, line2, 0)
+    call VSCodeCallRange('editor.action.formatSelection', line1, line2, 0)
 endfunction
 
 function! s:vscodeCommentary(...) abort
@@ -21,13 +21,13 @@ function! s:vscodeCommentary(...) abort
         let [line1, line2] = [line("'["), line("']")]
     endif
 
-    call VSCodeCallRange("editor.action.commentLine", line1, line2, 0)
+    call VSCodeCallRange('editor.action.commentLine', line1, line2, 0)
 endfunction
 
 function! s:vscodeGoToDefinition(str)
     if exists('b:vscode_controlled') && b:vscode_controlled
         exe "normal! m'"
-        call VSCodeNotify("editor.action.reveal" . a:str)
+        call VSCodeNotify('editor.action.reveal' . a:str)
     else
         " Allow to funcionar in help files
         exe "normal! \<C-]>"
@@ -41,14 +41,14 @@ endfunction
 
 function! s:openVSCodeCommandsInVisualMode()
     let mode = mode()
-    if mode ==# "V"
-        let startLine = line("v")
-        let endLine = line(".")
-        call VSCodeNotifyRange("workbench.action.showCommands", startLine, endLine, 1)
+    if mode ==# 'V'
+        let startLine = line('v')
+        let endLine = line('.')
+        call VSCodeNotifyRange('workbench.action.showCommands', startLine, endLine, 1)
     else
-        let startPos = getpos("v")
-        let endPos = getpos(".")
-        call VSCodeNotifyRangePos("workbench.action.showCommands", startPos[1], endPos[1], startPos[2], endPos[2] + 1, 1)
+        let startPos = getpos('v')
+        let endPos = getpos('.')
+        call VSCodeNotifyRangePos('workbench.action.showCommands', startPos[1], endPos[1], startPos[2], endPos[2] + 1, 1)
     endif
 endfunction
 
@@ -64,31 +64,31 @@ nnoremap <expr> = <SID>vscodeFormat()
 nnoremap <expr> == <SID>vscodeFormat() . '_'
 
 " gf/gF . Map to go to definition for now
-nnoremap <silent> K <Cmd>call VSCodeNotify('editor.action.showHover')<CR>
-nnoremap <silent> gh <Cmd>call VSCodeNotify('editor.action.showHover')<CR>
-nnoremap <silent> gf <Cmd>call <SID>vscodeGoToDefinition("Declaration")<CR>
-nnoremap <silent> gd <Cmd>call <SID>vscodeGoToDefinition("Definition")<CR>
-nnoremap <silent> <C-]> <Cmd>call <SID>vscodeGoToDefinition("Definition")<CR>
-nnoremap <silent> gO <Cmd>call <SID>vscodeNotifyWithMark('workbench.action.gotoSymbol')<CR>
-nnoremap <silent> gF <Cmd>call VSCodeNotify('editor.action.peekDeclaration')<CR>
-nnoremap <silent> gD <Cmd>call VSCodeNotify('editor.action.peekDefinition')<CR>
-nnoremap <silent> gH <Cmd>call VSCodeNotify('editor.action.referenceSearch.trigger')<CR>
+nnoremap K <Cmd>call VSCodeNotify('editor.action.showHover')<CR>
+nnoremap gh <Cmd>call VSCodeNotify('editor.action.showHover')<CR>
+nnoremap gf <Cmd>call <SID>vscodeGoToDefinition("Declaration")<CR>
+nnoremap gd <Cmd>call <SID>vscodeGoToDefinition("Definition")<CR>
+nnoremap <C-]> <Cmd>call <SID>vscodeGoToDefinition("Definition")<CR>
+nnoremap gO <Cmd>call <SID>vscodeNotifyWithMark('workbench.action.gotoSymbol')<CR>
+nnoremap gF <Cmd>call VSCodeNotify('editor.action.peekDeclaration')<CR>
+nnoremap gD <Cmd>call VSCodeNotify('editor.action.peekDefinition')<CR>
+nnoremap gH <Cmd>call VSCodeNotify('editor.action.referenceSearch.trigger')<CR>
 
-xnoremap <silent> K <Cmd>call VSCodeNotify('editor.action.showHover')<CR>
-xnoremap <silent> gh <Cmd>call VSCodeNotify('editor.action.showHover')<CR>
-xnoremap <silent> gf <Cmd>call <SID>vscodeGoToDefinition("Declaration")<CR>
-xnoremap <silent> gd <Cmd>call <SID>vscodeGoToDefinition("Definition")<CR>
-xnoremap <silent> <C-]> <Cmd>call <SID>vscodeGoToDefinition("Definition")<CR>
-xnoremap <silent> gO <Cmd>call <SID>vscodeNotifyWithMark('workbench.action.gotoSymbol')<CR>
-xnoremap <silent> gF <Cmd>call VSCodeNotify('editor.action.peekDeclaration')<CR>
-xnoremap <silent> gD <Cmd>call VSCodeNotify('editor.action.peekDefinition')<CR>
-xnoremap <silent> gH <Cmd>call VSCodeNotify('editor.action.referenceSearch.trigger')<CR>
+xnoremap K <Cmd>call VSCodeNotify('editor.action.showHover')<CR>
+xnoremap gh <Cmd>call VSCodeNotify('editor.action.showHover')<CR>
+xnoremap gf <Cmd>call <SID>vscodeGoToDefinition("Declaration")<CR>
+xnoremap gd <Cmd>call <SID>vscodeGoToDefinition("Definition")<CR>
+xnoremap <C-]> <Cmd>call <SID>vscodeGoToDefinition("Definition")<CR>
+xnoremap gO <Cmd>call <SID>vscodeNotifyWithMark('workbench.action.gotoSymbol')<CR>
+xnoremap gF <Cmd>call VSCodeNotify('editor.action.peekDeclaration')<CR>
+xnoremap gD <Cmd>call VSCodeNotify('editor.action.peekDefinition')<CR>
+xnoremap gH <Cmd>call VSCodeNotify('editor.action.referenceSearch.trigger')<CR>
 
 " <C-w> gf opens definition on the side
-nnoremap <silent> <C-w>gf <Cmd>call VSCodeNotify('editor.action.revealDeclarationAside')<CR>
-nnoremap <silent> <C-w>gd <Cmd>call VSCodeNotify('editor.action.revealDefinitionAside')<CR>
-xnoremap <silent> <C-w>gf <Cmd>call VSCodeNotify('editor.action.revealDeclarationAside')<CR>
-xnoremap <silent> <C-w>gd <Cmd>call VSCodeNotify('editor.action.revealDefinitionAside')<CR>
+nnoremap <C-w>gf <Cmd>call VSCodeNotify('editor.action.revealDeclarationAside')<CR>
+nnoremap <C-w>gd <Cmd>call VSCodeNotify('editor.action.revealDefinitionAside')<CR>
+xnoremap <C-w>gf <Cmd>call VSCodeNotify('editor.action.revealDeclarationAside')<CR>
+xnoremap <C-w>gd <Cmd>call VSCodeNotify('editor.action.revealDefinitionAside')<CR>
 
 " Bind C-/ to vscode commentary since calling from vscode produces double comments due to multiple cursors
 xnoremap <expr> <C-/> <SID>vscodeCommentary()

--- a/vim/vscode-code-actions.vim
+++ b/vim/vscode-code-actions.vim
@@ -39,13 +39,7 @@ function! s:vscodeNotifyWithMark(command)
   call VSCodeNotify(a:command)
 endfunction
 
-function! s:hover()
-  normal! gv
-  call VSCodeNotify('editor.action.showHover')
-endfunction
-
 function! s:openVSCodeCommandsInVisualMode()
-    normal! gv
     let visualmode = visualmode()
     if visualmode ==# "V"
         let startLine = line("v")
@@ -70,39 +64,39 @@ nnoremap <expr> = <SID>vscodeFormat()
 nnoremap <expr> == <SID>vscodeFormat() . '_'
 
 " gf/gF . Map to go to definition for now
-nnoremap <silent> K :<C-u>call VSCodeNotify('editor.action.showHover')<CR>
-nnoremap <silent> gh :<C-u>call VSCodeNotify('editor.action.showHover')<CR>
-nnoremap <silent> gf :<C-u>call <SID>vscodeGoToDefinition("Declaration")<CR>
-nnoremap <silent> gd :<C-u>call <SID>vscodeGoToDefinition("Definition")<CR>
-nnoremap <silent> <C-]> :<C-u>call <SID>vscodeGoToDefinition("Definition")<CR>
-nnoremap <silent> gO :<C-u>call <SID>vscodeNotifyWithMark('workbench.action.gotoSymbol')<CR>
-nnoremap <silent> gF :<C-u>call VSCodeNotify('editor.action.peekDeclaration')<CR>
-nnoremap <silent> gD :<C-u>call VSCodeNotify('editor.action.peekDefinition')<CR>
-nnoremap <silent> gH :<C-u>call VSCodeNotify('editor.action.referenceSearch.trigger')<CR>
+nnoremap <silent> K <Cmd>call VSCodeNotify('editor.action.showHover')<CR>
+nnoremap <silent> gh <Cmd>call VSCodeNotify('editor.action.showHover')<CR>
+nnoremap <silent> gf <Cmd>call <SID>vscodeGoToDefinition("Declaration")<CR>
+nnoremap <silent> gd <Cmd>call <SID>vscodeGoToDefinition("Definition")<CR>
+nnoremap <silent> <C-]> <Cmd>call <SID>vscodeGoToDefinition("Definition")<CR>
+nnoremap <silent> gO <Cmd>call <SID>vscodeNotifyWithMark('workbench.action.gotoSymbol')<CR>
+nnoremap <silent> gF <Cmd>call VSCodeNotify('editor.action.peekDeclaration')<CR>
+nnoremap <silent> gD <Cmd>call VSCodeNotify('editor.action.peekDefinition')<CR>
+nnoremap <silent> gH <Cmd>call VSCodeNotify('editor.action.referenceSearch.trigger')<CR>
 
-xnoremap <silent> K :<C-u>call <SID>hover()<CR>
-xnoremap <silent> gh :<C-u>call <SID>hover()<CR>
-xnoremap <silent> gf :<C-u>call <SID>vscodeGoToDefinition("Declaration")<CR>
-xnoremap <silent> gd :<C-u>call <SID>vscodeGoToDefinition("Definition")<CR>
-xnoremap <silent> <C-]> :<C-u>call <SID>vscodeGoToDefinition("Definition")<CR>
-xnoremap <silent> gO :<C-u>call <SID>vscodeNotifyWithMark('workbench.action.gotoSymbol')<CR>
-xnoremap <silent> gF :<C-u>call VSCodeNotify('editor.action.peekDeclaration')<CR>
-xnoremap <silent> gD :<C-u>call VSCodeNotify('editor.action.peekDefinition')<CR>
-xnoremap <silent> gH :<C-u>call VSCodeNotify('editor.action.referenceSearch.trigger')<CR>
+xnoremap <silent> K <Cmd>call VSCodeNotify('editor.action.showHover')<CR>
+xnoremap <silent> gh <Cmd>call VSCodeNotify('editor.action.showHover')<CR>
+xnoremap <silent> gf <Cmd>call <SID>vscodeGoToDefinition("Declaration")<CR>
+xnoremap <silent> gd <Cmd>call <SID>vscodeGoToDefinition("Definition")<CR>
+xnoremap <silent> <C-]> <Cmd>call <SID>vscodeGoToDefinition("Definition")<CR>
+xnoremap <silent> gO <Cmd>call <SID>vscodeNotifyWithMark('workbench.action.gotoSymbol')<CR>
+xnoremap <silent> gF <Cmd>call VSCodeNotify('editor.action.peekDeclaration')<CR>
+xnoremap <silent> gD <Cmd>call VSCodeNotify('editor.action.peekDefinition')<CR>
+xnoremap <silent> gH <Cmd>call VSCodeNotify('editor.action.referenceSearch.trigger')<CR>
 
 " <C-w> gf opens definition on the side
-nnoremap <silent> <C-w>gf :<C-u>call VSCodeNotify('editor.action.revealDeclarationAside')<CR>
-nnoremap <silent> <C-w>gd :<C-u>call VSCodeNotify('editor.action.revealDefinitionAside')<CR>
-xnoremap <silent> <C-w>gf :<C-u>call VSCodeNotify('editor.action.revealDeclarationAside')<CR>
-xnoremap <silent> <C-w>gd :<C-u>call VSCodeNotify('editor.action.revealDefinitionAside')<CR>
+nnoremap <silent> <C-w>gf <Cmd>call VSCodeNotify('editor.action.revealDeclarationAside')<CR>
+nnoremap <silent> <C-w>gd <Cmd>call VSCodeNotify('editor.action.revealDefinitionAside')<CR>
+xnoremap <silent> <C-w>gf <Cmd>call VSCodeNotify('editor.action.revealDeclarationAside')<CR>
+xnoremap <silent> <C-w>gd <Cmd>call VSCodeNotify('editor.action.revealDefinitionAside')<CR>
 
 " Bind C-/ to vscode commentary since calling from vscode produces double comments due to multiple cursors
 xnoremap <expr> <C-/> <SID>vscodeCommentary()
 nnoremap <expr> <C-/> <SID>vscodeCommentary() . '_'
 
 " Workaround for gk/gj
-nnoremap gk :<C-u>call VSCodeCall('cursorMove', { 'to': 'up', 'by': 'wrappedLine', 'value': v:count ? v:count : 1 })<CR>
-nnoremap gj :<C-u>call VSCodeCall('cursorMove', { 'to': 'down', 'by': 'wrappedLine', 'value': v:count ? v:count : 1 })<CR>
+nnoremap gk <Cmd>call VSCodeCall('cursorMove', { 'to': 'up', 'by': 'wrappedLine', 'value': v:count ? v:count : 1 })<CR>
+nnoremap gj <Cmd>call VSCodeCall('cursorMove', { 'to': 'down', 'by': 'wrappedLine', 'value': v:count ? v:count : 1 })<CR>
 
 " workaround for calling command picker in visual mode
-xnoremap <silent> <C-P> :<C-u>call <SID>openVSCodeCommandsInVisualMode()<CR>
+xnoremap <silent> <C-P> <Cmd>call <SID>openVSCodeCommandsInVisualMode()<CR>

--- a/vim/vscode-code-actions.vim
+++ b/vim/vscode-code-actions.vim
@@ -40,6 +40,7 @@ function! s:vscodeNotifyWithMark(command)
 endfunction
 
 function! s:openVSCodeCommandsInVisualMode()
+    normal! gv
     let visualmode = visualmode()
     if visualmode ==# "V"
         let startLine = line("v")
@@ -99,4 +100,4 @@ nnoremap gk <Cmd>call VSCodeCall('cursorMove', { 'to': 'up', 'by': 'wrappedLine'
 nnoremap gj <Cmd>call VSCodeCall('cursorMove', { 'to': 'down', 'by': 'wrappedLine', 'value': v:count ? v:count : 1 })<CR>
 
 " workaround for calling command picker in visual mode
-xnoremap <silent> <C-P> <Cmd>call <SID>openVSCodeCommandsInVisualMode()<CR>
+xnoremap <silent> <C-P> :<C-u>call <SID>openVSCodeCommandsInVisualMode()<CR>

--- a/vim/vscode-code-actions.vim
+++ b/vim/vscode-code-actions.vim
@@ -40,9 +40,8 @@ function! s:vscodeNotifyWithMark(command)
 endfunction
 
 function! s:openVSCodeCommandsInVisualMode()
-    normal! gv
-    let visualmode = visualmode()
-    if visualmode ==# "V"
+    let mode = mode()
+    if mode ==# "V"
         let startLine = line("v")
         let endLine = line(".")
         call VSCodeNotifyRange("workbench.action.showCommands", startLine, endLine, 1)
@@ -100,4 +99,4 @@ nnoremap gk <Cmd>call VSCodeCall('cursorMove', { 'to': 'up', 'by': 'wrappedLine'
 nnoremap gj <Cmd>call VSCodeCall('cursorMove', { 'to': 'down', 'by': 'wrappedLine', 'value': v:count ? v:count : 1 })<CR>
 
 " workaround for calling command picker in visual mode
-xnoremap <silent> <C-P> :<C-u>call <SID>openVSCodeCommandsInVisualMode()<CR>
+xnoremap <C-P> <Cmd>call <SID>openVSCodeCommandsInVisualMode()<CR>

--- a/vim/vscode-file-commands.vim
+++ b/vim/vscode-file-commands.vim
@@ -57,5 +57,5 @@ AlterCommand qa[ll] Qall
 AlterCommand wqa[ll] Wqall
 AlterCommand xa[ll] Xall
 
-nnoremap <silent> ZZ :Wq<CR>
-nnoremap <silent> ZQ :Quit!<CR>
+nnoremap ZZ <Cmd>Wq<CR>
+nnoremap ZQ <Cmd>Quit!<CR>

--- a/vim/vscode-insert.vim
+++ b/vim/vscode-insert.vim
@@ -1,14 +1,14 @@
 
 function! s:vscodePrepareMultipleCursors(append, skipEmpty)
-    let m = visualmode()
-    if m ==# "V" || m ==# "\<C-v>"
+    let m = mode()
+    if m ==# 'V' || m ==# "\<C-v>"
         let b:notifyMultipleCursors = 1
         let b:multipleCursorsVisualMode = m
         let b:multipleCursorsAppend = a:append
         let b:multipleCursorsSkipEmpty = a:skipEmpty
         " We need to start insert, then spawn cursors otherwise they'll be destroyed
         " using feedkeys() here because :startinsert is being delayed
-        call feedkeys('i', 'n')
+        call feedkeys("o\<Esc>i", 'n')
     endif
 endfunction
 
@@ -25,7 +25,7 @@ augroup MultipleCursors
 augroup END
 
 " Multiple cursors support for visual line/block modes
-xnoremap <silent> ma :<C-u>call <SID>vscodePrepareMultipleCursors(1, 1)<CR>
-xnoremap <silent> mi :<C-u>call <SID>vscodePrepareMultipleCursors(0, 1)<CR>
-xnoremap <silent> mA :<C-u>call <SID>vscodePrepareMultipleCursors(1, 0)<CR>
-xnoremap <silent> mI :<C-u>call <SID>vscodePrepareMultipleCursors(0, 0)<CR>
+xnoremap ma <Cmd>call <SID>vscodePrepareMultipleCursors(1, 1)<CR>
+xnoremap mi <Cmd>call <SID>vscodePrepareMultipleCursors(0, 1)<CR>
+xnoremap mA <Cmd>call <SID>vscodePrepareMultipleCursors(1, 0)<CR>
+xnoremap mI <Cmd>call <SID>vscodePrepareMultipleCursors(0, 0)<CR>

--- a/vim/vscode-insert.vim
+++ b/vim/vscode-insert.vim
@@ -25,7 +25,7 @@ augroup MultipleCursors
 augroup END
 
 " Multiple cursors support for visual line/block modes
-xnoremap <silent> ma <Cmd>call <SID>vscodePrepareMultipleCursors(1, 1)<CR>
-xnoremap <silent> mi <Cmd>call <SID>vscodePrepareMultipleCursors(0, 1)<CR>
-xnoremap <silent> mA <Cmd>call <SID>vscodePrepareMultipleCursors(1, 0)<CR>
-xnoremap <silent> mI <Cmd>call <SID>vscodePrepareMultipleCursors(0, 0)<CR>
+xnoremap <silent> ma :<C-u>call <SID>vscodePrepareMultipleCursors(1, 1)<CR>
+xnoremap <silent> mi :<C-u>call <SID>vscodePrepareMultipleCursors(0, 1)<CR>
+xnoremap <silent> mA :<C-u>call <SID>vscodePrepareMultipleCursors(1, 0)<CR>
+xnoremap <silent> mI :<C-u>call <SID>vscodePrepareMultipleCursors(0, 0)<CR>

--- a/vim/vscode-insert.vim
+++ b/vim/vscode-insert.vim
@@ -25,7 +25,7 @@ augroup MultipleCursors
 augroup END
 
 " Multiple cursors support for visual line/block modes
-xnoremap <silent> ma :<C-u>call <SID>vscodePrepareMultipleCursors(1, 1)<CR>
-xnoremap <silent> mi :<C-u>call <SID>vscodePrepareMultipleCursors(0, 1)<CR>
-xnoremap <silent> mA :<C-u>call <SID>vscodePrepareMultipleCursors(1, 0)<CR>
-xnoremap <silent> mI :<C-u>call <SID>vscodePrepareMultipleCursors(0, 0)<CR>
+xnoremap <silent> ma <Cmd>call <SID>vscodePrepareMultipleCursors(1, 1)<CR>
+xnoremap <silent> mi <Cmd>call <SID>vscodePrepareMultipleCursors(0, 1)<CR>
+xnoremap <silent> mA <Cmd>call <SID>vscodePrepareMultipleCursors(1, 0)<CR>
+xnoremap <silent> mI <Cmd>call <SID>vscodePrepareMultipleCursors(0, 0)<CR>

--- a/vim/vscode-jumplist.vim
+++ b/vim/vscode-jumplist.vim
@@ -1,8 +1,8 @@
 
 " VIM jumplist is used now
-" nnoremap <silent> <C-o> :<C-u>call VSCodeNotify("workbench.action.navigateBack")<CR>
-" nnoremap <silent> <C-i> :<C-u>call VSCodeNotify("workbench.action.navigateForward")<CR>
-" nnoremap <silent> <Tab> :<C-u>call VSCodeNotify("workbench.action.navigateForward")<CR>
+" nnoremap <silent> <C-o> <Cmd>call VSCodeNotify("workbench.action.navigateBack")<CR>
+" nnoremap <silent> <C-i> <Cmd>call VSCodeNotify("workbench.action.navigateForward")<CR>
+" nnoremap <silent> <Tab> <Cmd>call VSCodeNotify("workbench.action.navigateForward")<CR>
 
 function s:jump(forward)
     let g:isJumping = 1
@@ -23,7 +23,7 @@ augroup VscodeJumplist
 augroup END
 
 
-nnoremap <silent> <C-o> :<C-u>call <SID>jump(0)<CR>
-nnoremap <silent> <C-i> :<C-u>call <SID>jump(1)<CR>
-nnoremap <silent> <Tab> :<C-u>call <SID>jump(1)<CR>
+nnoremap <silent> <C-o> <Cmd>call <SID>jump(0)<CR>
+nnoremap <silent> <C-i> <Cmd>call <SID>jump(1)<CR>
+nnoremap <silent> <Tab> <Cmd>call <SID>jump(1)<CR>
 

--- a/vim/vscode-jumplist.vim
+++ b/vim/vscode-jumplist.vim
@@ -11,7 +11,7 @@ function s:jump(forward)
 endfunction
 
 function! s:clearJumplist()
-    if exists("w:vscode_clearjumps") && w:vscode_clearjumps
+    if exists('w:vscode_clearjumps') && w:vscode_clearjumps
         let w:vscode_clearjumps = 0
         clearjumps
     endif
@@ -23,7 +23,7 @@ augroup VscodeJumplist
 augroup END
 
 
-nnoremap <silent> <C-o> <Cmd>call <SID>jump(0)<CR>
-nnoremap <silent> <C-i> <Cmd>call <SID>jump(1)<CR>
-nnoremap <silent> <Tab> <Cmd>call <SID>jump(1)<CR>
+nnoremap <C-o> <Cmd>call <SID>jump(0)<CR>
+nnoremap <C-i> <Cmd>call <SID>jump(1)<CR>
+nnoremap <Tab> <Cmd>call <SID>jump(1)<CR>
 

--- a/vim/vscode-neovim.vim
+++ b/vim/vscode-neovim.vim
@@ -6,11 +6,11 @@ let s:currDir = fnamemodify(resolve(expand('<sfile>:p')), ':h')
 let &runtimepath = &runtimepath . ',' . s:currDir . '/vim-altercmd'
 
 " Used to execute vscode command
-let s:vscodeCommandEventName = "vscode-command"
+let s:vscodeCommandEventName = 'vscode-command'
 " Used to execute vscode command with some range (the specified range will be selected and the command will be executed on this range)
-let s:vscodeRangeCommandEventName = "vscode-range-command"
+let s:vscodeRangeCommandEventName = 'vscode-range-command'
 " Used for externsion inter-communications
-let s:vscodePluginEventName = "vscode-neovim"
+let s:vscodePluginEventName = 'vscode-neovim'
 
 " RPC and global functions
 
@@ -108,7 +108,7 @@ function! s:onBufEnter(name, id)
     set conceallevel=0
     let tabstop = &tabstop
     let isJumping = 0
-    if exists("g:isJumping")
+    if exists('g:isJumping')
         let isJumping = g:isJumping
     endif
     call VSCodeExtensionCall('external-buffer', a:name, a:id, 1, tabstop, isJumping)
@@ -124,7 +124,7 @@ endfunction
 
 function! s:onInsertEnter()
     let reg = reg_recording()
-    if reg != ""
+    if !empty(reg)
         call VSCodeExtensionCall('notify-recording', reg)
     endif
 endfunction

--- a/vim/vscode-options.vim
+++ b/vim/vscode-options.vim
@@ -1,5 +1,7 @@
 " This file used to force set neovim options which may break the extension. Loaded after user config
 
+scriptencoding utf-8
+
 set shortmess=filnxtToOFI
 set nowrap
 set mouse=a

--- a/vim/vscode-scrolling.vim
+++ b/vim/vscode-scrolling.vim
@@ -1,22 +1,19 @@
-function s:reveal(direction, resetCursor, restoreVisual)
-    if a:restoreVisual
-        normal! gv
-    endif
+function s:reveal(direction, resetCursor)
     call VSCodeExtensionNotify('reveal', a:direction, a:resetCursor)
 endfunction
 
-nnoremap <silent> z<CR> :<C-u>call <SID>reveal('top', 1, 0)<CR>
-xnoremap <silent> z<CR> :<C-u>call <SID>reveal('top', 1, 1)<CR>
-nnoremap <silent> zt :<C-u>call <SID>reveal('top', 0, 0)<CR>
-xnoremap <silent> zt :<C-u>call <SID>reveal('top', 0, 1)<CR>
-nnoremap <silent> z. :<C-u>call <SID>reveal('center', 1, 0)<CR>
-xnoremap <silent> z. :<C-u>call <SID>reveal('center', 1, 1)<CR>
-nnoremap <silent> zz :<C-u>call <SID>reveal('center', 0, 0)<CR>
-xnoremap <silent> zz :<C-u>call <SID>reveal('center', 0, 1)<CR>
-nnoremap <silent> z- :<C-u>call <SID>reveal('bottom', 1, 0)<CR>
-xnoremap <silent> z- :<C-u>call <SID>reveal('bottom', 1, 1)<CR>
-nnoremap <silent> zb :<C-u>call <SID>reveal('bottom', 0, 0)<CR>
-xnoremap <silent> zb :<C-u>call <SID>reveal('bottom', 0, 1)<CR>
+nnoremap <silent> z<CR> <Cmd>call <SID>reveal('top', 1)<CR>
+xnoremap <silent> z<CR> <Cmd>call <SID>reveal('top', 1)<CR>
+nnoremap <silent> zt <Cmd>call <SID>reveal('top', 0)<CR>
+xnoremap <silent> zt <Cmd>call <SID>reveal('top', 0)<CR>
+nnoremap <silent> z. <Cmd>call <SID>reveal('center', 1)<CR>
+xnoremap <silent> z. <Cmd>call <SID>reveal('center', 1)<CR>
+nnoremap <silent> zz <Cmd>call <SID>reveal('center', 0)<CR>
+xnoremap <silent> zz <Cmd>call <SID>reveal('center', 0)<CR>
+nnoremap <silent> z- <Cmd>call <SID>reveal('bottom', 1)<CR>
+xnoremap <silent> z- <Cmd>call <SID>reveal('bottom', 1)<CR>
+nnoremap <silent> zb <Cmd>call <SID>reveal('bottom', 0)<CR>
+xnoremap <silent> zb <Cmd>call <SID>reveal('bottom', 0)<CR>
 
 nnoremap <silent> <expr> H VSCodeExtensionNotify('move-cursor', 'top')
 xnoremap <silent> <expr> H VSCodeExtensionNotify('move-cursor', 'top')

--- a/vim/vscode-scrolling.vim
+++ b/vim/vscode-scrolling.vim
@@ -2,25 +2,25 @@ function s:reveal(direction, resetCursor)
     call VSCodeExtensionNotify('reveal', a:direction, a:resetCursor)
 endfunction
 
-nnoremap <silent> z<CR> <Cmd>call <SID>reveal('top', 1)<CR>
-xnoremap <silent> z<CR> <Cmd>call <SID>reveal('top', 1)<CR>
-nnoremap <silent> zt <Cmd>call <SID>reveal('top', 0)<CR>
-xnoremap <silent> zt <Cmd>call <SID>reveal('top', 0)<CR>
-nnoremap <silent> z. <Cmd>call <SID>reveal('center', 1)<CR>
-xnoremap <silent> z. <Cmd>call <SID>reveal('center', 1)<CR>
-nnoremap <silent> zz <Cmd>call <SID>reveal('center', 0)<CR>
-xnoremap <silent> zz <Cmd>call <SID>reveal('center', 0)<CR>
-nnoremap <silent> z- <Cmd>call <SID>reveal('bottom', 1)<CR>
-xnoremap <silent> z- <Cmd>call <SID>reveal('bottom', 1)<CR>
-nnoremap <silent> zb <Cmd>call <SID>reveal('bottom', 0)<CR>
-xnoremap <silent> zb <Cmd>call <SID>reveal('bottom', 0)<CR>
+nnoremap z<CR> <Cmd>call <SID>reveal('top', 1)<CR>
+xnoremap z<CR> <Cmd>call <SID>reveal('top', 1)<CR>
+nnoremap zt <Cmd>call <SID>reveal('top', 0)<CR>
+xnoremap zt <Cmd>call <SID>reveal('top', 0)<CR>
+nnoremap z. <Cmd>call <SID>reveal('center', 1)<CR>
+xnoremap z. <Cmd>call <SID>reveal('center', 1)<CR>
+nnoremap zz <Cmd>call <SID>reveal('center', 0)<CR>
+xnoremap zz <Cmd>call <SID>reveal('center', 0)<CR>
+nnoremap z- <Cmd>call <SID>reveal('bottom', 1)<CR>
+xnoremap z- <Cmd>call <SID>reveal('bottom', 1)<CR>
+nnoremap zb <Cmd>call <SID>reveal('bottom', 0)<CR>
+xnoremap zb <Cmd>call <SID>reveal('bottom', 0)<CR>
 
-nnoremap <silent> <expr> H VSCodeExtensionNotify('move-cursor', 'top')
-xnoremap <silent> <expr> H VSCodeExtensionNotify('move-cursor', 'top')
-nnoremap <silent> <expr> M VSCodeExtensionNotify('move-cursor', 'middle')
-xnoremap <silent> <expr> M VSCodeExtensionNotify('move-cursor', 'middle')
-nnoremap <silent> <expr> L VSCodeExtensionNotify('move-cursor', 'bottom')
-xnoremap <silent> <expr> L VSCodeExtensionNotify('move-cursor', 'bottom')
+nnoremap <expr> H VSCodeExtensionNotify('move-cursor', 'top')
+xnoremap <expr> H VSCodeExtensionNotify('move-cursor', 'top')
+nnoremap <expr> M VSCodeExtensionNotify('move-cursor', 'middle')
+xnoremap <expr> M VSCodeExtensionNotify('move-cursor', 'middle')
+nnoremap <expr> L VSCodeExtensionNotify('move-cursor', 'bottom')
+xnoremap <expr> L VSCodeExtensionNotify('move-cursor', 'bottom')
 
 " Disabled due to scroll problems (the ext binds them directly)
 " nnoremap <silent> <expr> <C-d> VSCodeExtensionCall('scroll', 'halfPage', 'down')

--- a/vim/vscode-tab-commands.vim
+++ b/vim/vscode-tab-commands.vim
@@ -34,7 +34,7 @@ AlterCommand tabfir[st] Tabfirst
 AlterCommand tabl[ast] Tablast
 AlterCommand tabm[ove] Tabmove
 
-nnoremap <silent> gt <Cmd>call <SID>switchEditor(v:count, 'next')<CR>
-xnoremap <silent> gt <Cmd>call <SID>switchEditor(v:count, 'next')<CR>
-nnoremap <silent> gT <Cmd>call <SID>switchEditor(v:count, 'prev')<CR>
-xnoremap <silent> gT <Cmd>call <SID>switchEditor(v:count, 'prev')<CR>
+nnoremap gt <Cmd>call <SID>switchEditor(v:count, 'next')<CR>
+xnoremap gt <Cmd>call <SID>switchEditor(v:count, 'next')<CR>
+nnoremap gT <Cmd>call <SID>switchEditor(v:count, 'prev')<CR>
+xnoremap gT <Cmd>call <SID>switchEditor(v:count, 'prev')<CR>

--- a/vim/vscode-tab-commands.vim
+++ b/vim/vscode-tab-commands.vim
@@ -34,8 +34,7 @@ AlterCommand tabfir[st] Tabfirst
 AlterCommand tabl[ast] Tablast
 AlterCommand tabm[ove] Tabmove
 
-" <C-u> is needed to clear prev count
-nnoremap <silent> gt :<C-U>call <SID>switchEditor(v:count, 'next')<CR>
-xnoremap <silent> gt :<C-U>call <SID>switchEditor(v:count, 'next')<CR>
-nnoremap <silent> gT :<C-U>call <SID>switchEditor(v:count, 'prev')<CR>
-xnoremap <silent> gT :<C-U>call <SID>switchEditor(v:count, 'prev')<CR>
+nnoremap <silent> gt <Cmd>call <SID>switchEditor(v:count, 'next')<CR>
+xnoremap <silent> gt <Cmd>call <SID>switchEditor(v:count, 'next')<CR>
+nnoremap <silent> gT <Cmd>call <SID>switchEditor(v:count, 'prev')<CR>
+xnoremap <silent> gT <Cmd>call <SID>switchEditor(v:count, 'prev')<CR>

--- a/vim/vscode-window-commands.vim
+++ b/vim/vscode-window-commands.vim
@@ -3,7 +3,7 @@ function! s:split(...) abort
     let direction = a:1
     let file = exists('a:2') ? a:2 : ''
     call VSCodeCall(direction ==# 'h' ? 'workbench.action.splitEditorDown' : 'workbench.action.splitEditorRight')
-    if file != ''
+    if !empty(file)
         call VSCodeExtensionNotify('open-file', expand(file), 'all')
     endif
 endfunction
@@ -38,65 +38,65 @@ AlterCommand new New
 AlterCommand vne[w] Vnew
 AlterCommand on[ly] Only
 
-nnoremap <silent> <C-w>s <Cmd>call <SID>split('h')<CR>
-xnoremap <silent> <C-w>s <Cmd>call <SID>split('h')<CR>
+nnoremap <C-w>s <Cmd>call <SID>split('h')<CR>
+xnoremap <C-w>s <Cmd>call <SID>split('h')<CR>
 
-nnoremap <silent> <C-w>v <Cmd>call <SID>split('v')<CR>
-xnoremap <silent> <C-w>v <Cmd>call <SID>split('v')<CR>
+nnoremap <C-w>v <Cmd>call <SID>split('v')<CR>
+xnoremap <C-w>v <Cmd>call <SID>split('v')<CR>
 
-nnoremap <silent> <C-w>n <Cmd>call <SID>splitNew('h', '__vscode_new__')<CR>
-xnoremap <silent> <C-w>n <Cmd>call <SID>splitNew('h', '__vscode_new__')<CR>
+nnoremap <C-w>n <Cmd>call <SID>splitNew('h', '__vscode_new__')<CR>
+xnoremap <C-w>n <Cmd>call <SID>splitNew('h', '__vscode_new__')<CR>
 
-nnoremap <silent> <C-w>q <Cmd>call VSCodeNotify('workbench.action.closeActiveEditor')<CR>
-xnoremap <silent> <C-w>q <Cmd>call VSCodeNotify('workbench.action.closeActiveEditor')<CR>
-nnoremap <silent> <C-w>c <Cmd>call VSCodeNotify('workbench.action.closeActiveEditor')<CR>
-xnoremap <silent> <C-w>c <Cmd>call VSCodeNotify('workbench.action.closeActiveEditor')<CR>
+nnoremap <C-w>q <Cmd>call VSCodeNotify('workbench.action.closeActiveEditor')<CR>
+xnoremap <C-w>q <Cmd>call VSCodeNotify('workbench.action.closeActiveEditor')<CR>
+nnoremap <C-w>c <Cmd>call VSCodeNotify('workbench.action.closeActiveEditor')<CR>
+xnoremap <C-w>c <Cmd>call VSCodeNotify('workbench.action.closeActiveEditor')<CR>
 
-nnoremap <silent> <C-w>o <Cmd>call VSCodeNotify('workbench.action.joinAllGroups')<CR>
-xnoremap <silent> <C-w>o <Cmd>call VSCodeNotify('workbench.action.joinAllGroups')<CR>
+nnoremap <C-w>o <Cmd>call VSCodeNotify('workbench.action.joinAllGroups')<CR>
+xnoremap <C-w>o <Cmd>call VSCodeNotify('workbench.action.joinAllGroups')<CR>
 
-nnoremap <silent> <C-w>j <Cmd>call VSCodeNotify('workbench.action.focusBelowGroup')<CR>
-xnoremap <silent> <C-w>j <Cmd>call VSCodeNotify('workbench.action.focusBelowGroup')<CR>
-nnoremap <silent> <C-w><C-j> <Cmd>call VSCodeNotify('workbench.action.moveEditorToBelowGroup')<CR>
-xnoremap <silent> <C-w><C-j> <Cmd>call VSCodeNotify('workbench.action.moveEditorToBelowGroup')<CR>
-nnoremap <silent> <C-w>k <Cmd>call VSCodeNotify('workbench.action.focusAboveGroup')<CR>
-xnoremap <silent> <C-w>k <Cmd>call VSCodeNotify('workbench.action.focusAboveGroup')<CR>
-nnoremap <silent> <C-w><C-i> <Cmd>call VSCodeNotify('workbench.action.moveEditorToAboveGroup')<CR>
-xnoremap <silent> <C-w><C-i> <Cmd>call VSCodeNotify('workbench.action.moveEditorToAboveGroup')<CR>
-nnoremap <silent> <C-w>h <Cmd>call VSCodeNotify('workbench.action.focusLeftGroup')<CR>
-xnoremap <silent> <C-w>h <Cmd>call VSCodeNotify('workbench.action.focusLeftGroup')<CR>
-nnoremap <silent> <C-w><C-h> <Cmd>call VSCodeNotify('workbench.action.moveEditorToLeftGroup')<CR>
-xnoremap <silent> <C-w><C-h> <Cmd>call VSCodeNotify('workbench.action.moveEditorToLeftGroup')<CR>
-nnoremap <silent> <C-w>l <Cmd>call VSCodeNotify('workbench.action.focusRightGroup')<CR>
-xnoremap <silent> <C-w>l <Cmd>call VSCodeNotify('workbench.action.focusRightGroup')<CR>
-nnoremap <silent> <C-w><C-l> <Cmd>call VSCodeNotify('workbench.action.moveEditorToRightGroup')<CR>
-xnoremap <silent> <C-w><C-l> <Cmd>call VSCodeNotify('workbench.action.moveEditorToRightGroup')<CR>
-nnoremap <silent> <C-w>w <Cmd>call VSCodeNotify('workbench.action.focusNextGroup')<CR>
-xnoremap <silent> <C-w>w <Cmd>call VSCodeNotify('workbench.action.focusNextGroup')<CR>
-nnoremap <silent> <C-w><C-w> <Cmd>call VSCodeNotify('workbench.action.focusNextGroup')<CR>
-xnoremap <silent> <C-w><C-w> <Cmd>call VSCodeNotify('workbench.action.focusNextGroup')<CR>
-nnoremap <silent> <C-w>W <Cmd>call VSCodeNotify('workbench.action.focusPreviousGroup')<CR>
-xnoremap <silent> <C-w>W <Cmd>call VSCodeNotify('workbench.action.focusPreviousGroup')<CR>
-nnoremap <silent> <C-w>p <Cmd>call VSCodeNotify('workbench.action.focusPreviousGroup')<CR>
-xnoremap <silent> <C-w>p <Cmd>call VSCodeNotify('workbench.action.focusPreviousGroup')<CR>
-nnoremap <silent> <C-w>t <Cmd>call VSCodeNotify('workbench.action.focusFirstEditorGroup')<CR>
-xnoremap <silent> <C-w>t <Cmd>call VSCodeNotify('workbench.action.focusFirstEditorGroup')<CR>
-nnoremap <silent> <C-w>b <Cmd>call VSCodeNotify('workbench.action.focusLastEditorGroup')<CR>
-xnoremap <silent> <C-w>b <Cmd>call VSCodeNotify('workbench.action.focusLastEditorGroup')<CR>
+nnoremap <C-w>j <Cmd>call VSCodeNotify('workbench.action.focusBelowGroup')<CR>
+xnoremap <C-w>j <Cmd>call VSCodeNotify('workbench.action.focusBelowGroup')<CR>
+nnoremap <C-w><C-j> <Cmd>call VSCodeNotify('workbench.action.moveEditorToBelowGroup')<CR>
+xnoremap <C-w><C-j> <Cmd>call VSCodeNotify('workbench.action.moveEditorToBelowGroup')<CR>
+nnoremap <C-w>k <Cmd>call VSCodeNotify('workbench.action.focusAboveGroup')<CR>
+xnoremap <C-w>k <Cmd>call VSCodeNotify('workbench.action.focusAboveGroup')<CR>
+nnoremap <C-w><C-i> <Cmd>call VSCodeNotify('workbench.action.moveEditorToAboveGroup')<CR>
+xnoremap <C-w><C-i> <Cmd>call VSCodeNotify('workbench.action.moveEditorToAboveGroup')<CR>
+nnoremap <C-w>h <Cmd>call VSCodeNotify('workbench.action.focusLeftGroup')<CR>
+xnoremap <C-w>h <Cmd>call VSCodeNotify('workbench.action.focusLeftGroup')<CR>
+nnoremap <C-w><C-h> <Cmd>call VSCodeNotify('workbench.action.moveEditorToLeftGroup')<CR>
+xnoremap <C-w><C-h> <Cmd>call VSCodeNotify('workbench.action.moveEditorToLeftGroup')<CR>
+nnoremap <C-w>l <Cmd>call VSCodeNotify('workbench.action.focusRightGroup')<CR>
+xnoremap <C-w>l <Cmd>call VSCodeNotify('workbench.action.focusRightGroup')<CR>
+nnoremap <C-w><C-l> <Cmd>call VSCodeNotify('workbench.action.moveEditorToRightGroup')<CR>
+xnoremap <C-w><C-l> <Cmd>call VSCodeNotify('workbench.action.moveEditorToRightGroup')<CR>
+nnoremap <C-w>w <Cmd>call VSCodeNotify('workbench.action.focusNextGroup')<CR>
+xnoremap <C-w>w <Cmd>call VSCodeNotify('workbench.action.focusNextGroup')<CR>
+nnoremap <C-w><C-w> <Cmd>call VSCodeNotify('workbench.action.focusNextGroup')<CR>
+xnoremap <C-w><C-w> <Cmd>call VSCodeNotify('workbench.action.focusNextGroup')<CR>
+nnoremap <C-w>W <Cmd>call VSCodeNotify('workbench.action.focusPreviousGroup')<CR>
+xnoremap <C-w>W <Cmd>call VSCodeNotify('workbench.action.focusPreviousGroup')<CR>
+nnoremap <C-w>p <Cmd>call VSCodeNotify('workbench.action.focusPreviousGroup')<CR>
+xnoremap <C-w>p <Cmd>call VSCodeNotify('workbench.action.focusPreviousGroup')<CR>
+nnoremap <C-w>t <Cmd>call VSCodeNotify('workbench.action.focusFirstEditorGroup')<CR>
+xnoremap <C-w>t <Cmd>call VSCodeNotify('workbench.action.focusFirstEditorGroup')<CR>
+nnoremap <C-w>b <Cmd>call VSCodeNotify('workbench.action.focusLastEditorGroup')<CR>
+xnoremap <C-w>b <Cmd>call VSCodeNotify('workbench.action.focusLastEditorGroup')<CR>
 
-nnoremap <silent> <C-w>= <Cmd>call VSCodeNotify('workbench.action.evenEditorWidths')<CR>
-xnoremap <silent> <C-w>= <Cmd>call VSCodeNotify('workbench.action.evenEditorWidths')<CR>
+nnoremap <C-w>= <Cmd>call VSCodeNotify('workbench.action.evenEditorWidths')<CR>
+xnoremap <C-w>= <Cmd>call VSCodeNotify('workbench.action.evenEditorWidths')<CR>
 
-nnoremap <silent> <C-w>> <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
-xnoremap <silent> <C-w>> <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
-nnoremap <silent> <C-w>+ <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
-xnoremap <silent> <C-w>+ <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
-nnoremap <silent> <C-w>< <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
-xnoremap <silent> <C-w>< <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
-nnoremap <silent> <C-w>- <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
-xnoremap <silent> <C-w>- <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
+nnoremap <C-w>> <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
+xnoremap <C-w>> <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
+nnoremap <C-w>+ <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
+xnoremap <C-w>+ <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
+nnoremap <C-w>< <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
+xnoremap <C-w>< <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
+nnoremap <C-w>- <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
+xnoremap <C-w>- <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
 
-nnoremap <silent> <C-w>_ <Cmd>call VSCodeNotify('workbench.action.toggleEditorWidths')<CR>
+nnoremap <C-w>_ <Cmd>call VSCodeNotify('workbench.action.toggleEditorWidths')<CR>
 
 nnoremap <C-w>H <Cmd>echoerr 'Not supported yet'<CR>
 xnoremap <C-w>H <Cmd>echoerr 'Not supported yet'<CR>

--- a/vim/vscode-window-commands.vim
+++ b/vim/vscode-window-commands.vim
@@ -38,71 +38,71 @@ AlterCommand new New
 AlterCommand vne[w] Vnew
 AlterCommand on[ly] Only
 
-nnoremap <silent> <C-w>s :<C-u>call <SID>split('h')<CR>
-xnoremap <silent> <C-w>s :<C-u>call <SID>split('h')<CR>
+nnoremap <silent> <C-w>s <Cmd>call <SID>split('h')<CR>
+xnoremap <silent> <C-w>s <Cmd>call <SID>split('h')<CR>
 
-nnoremap <silent> <C-w>v :<C-u>call <SID>split('v')<CR>
-xnoremap <silent> <C-w>v :<C-u>call <SID>split('v')<CR>
+nnoremap <silent> <C-w>v <Cmd>call <SID>split('v')<CR>
+xnoremap <silent> <C-w>v <Cmd>call <SID>split('v')<CR>
 
-nnoremap <silent> <C-w>n :<C-u>call <SID>splitNew('h', '__vscode_new__')<CR>
-xnoremap <silent> <C-w>n :<C-u>call <SID>splitNew('h', '__vscode_new__')<CR>
+nnoremap <silent> <C-w>n <Cmd>call <SID>splitNew('h', '__vscode_new__')<CR>
+xnoremap <silent> <C-w>n <Cmd>call <SID>splitNew('h', '__vscode_new__')<CR>
 
-nnoremap <silent> <C-w>q :<C-u>call VSCodeNotify('workbench.action.closeActiveEditor')<CR>
-xnoremap <silent> <C-w>q :<C-u>call VSCodeNotify('workbench.action.closeActiveEditor')<CR>
-nnoremap <silent> <C-w>c :<C-u>call VSCodeNotify('workbench.action.closeActiveEditor')<CR>
-xnoremap <silent> <C-w>c :<C-u>call VSCodeNotify('workbench.action.closeActiveEditor')<CR>
+nnoremap <silent> <C-w>q <Cmd>call VSCodeNotify('workbench.action.closeActiveEditor')<CR>
+xnoremap <silent> <C-w>q <Cmd>call VSCodeNotify('workbench.action.closeActiveEditor')<CR>
+nnoremap <silent> <C-w>c <Cmd>call VSCodeNotify('workbench.action.closeActiveEditor')<CR>
+xnoremap <silent> <C-w>c <Cmd>call VSCodeNotify('workbench.action.closeActiveEditor')<CR>
 
-nnoremap <silent> <C-w>o :<C-u>call VSCodeNotify('workbench.action.joinAllGroups')<CR>
-xnoremap <silent> <C-w>o :<C-u>call VSCodeNotify('workbench.action.joinAllGroups')<CR>
+nnoremap <silent> <C-w>o <Cmd>call VSCodeNotify('workbench.action.joinAllGroups')<CR>
+xnoremap <silent> <C-w>o <Cmd>call VSCodeNotify('workbench.action.joinAllGroups')<CR>
 
-nnoremap <silent> <C-w>j :<C-u>call VSCodeNotify('workbench.action.focusBelowGroup')<CR>
-xnoremap <silent> <C-w>j :<C-u>call VSCodeNotify('workbench.action.focusBelowGroup')<CR>
-nnoremap <silent> <C-w><C-j> :<C-u>call VSCodeNotify('workbench.action.moveEditorToBelowGroup')<CR>
-xnoremap <silent> <C-w><C-j> :<C-u>call VSCodeNotify('workbench.action.moveEditorToBelowGroup')<CR>
-nnoremap <silent> <C-w>k :<C-u>call VSCodeNotify('workbench.action.focusAboveGroup')<CR>
-xnoremap <silent> <C-w>k :<C-u>call VSCodeNotify('workbench.action.focusAboveGroup')<CR>
-nnoremap <silent> <C-w><C-i> :<C-u>call VSCodeNotify('workbench.action.moveEditorToAboveGroup')<CR>
-xnoremap <silent> <C-w><C-i> :<C-u>call VSCodeNotify('workbench.action.moveEditorToAboveGroup')<CR>
-nnoremap <silent> <C-w>h :<C-u>call VSCodeNotify('workbench.action.focusLeftGroup')<CR>
-xnoremap <silent> <C-w>h :<C-u>call VSCodeNotify('workbench.action.focusLeftGroup')<CR>
-nnoremap <silent> <C-w><C-h> :<C-u>call VSCodeNotify('workbench.action.moveEditorToLeftGroup')<CR>
-xnoremap <silent> <C-w><C-h> :<C-u>call VSCodeNotify('workbench.action.moveEditorToLeftGroup')<CR>
-nnoremap <silent> <C-w>l :<C-u>call VSCodeNotify('workbench.action.focusRightGroup')<CR>
-xnoremap <silent> <C-w>l :<C-u>call VSCodeNotify('workbench.action.focusRightGroup')<CR>
-nnoremap <silent> <C-w><C-l> :<C-u>call VSCodeNotify('workbench.action.moveEditorToRightGroup')<CR>
-xnoremap <silent> <C-w><C-l> :<C-u>call VSCodeNotify('workbench.action.moveEditorToRightGroup')<CR>
-nnoremap <silent> <C-w>w :<C-u>call VSCodeNotify('workbench.action.focusNextGroup')<CR>
-xnoremap <silent> <C-w>w :<C-u>call VSCodeNotify('workbench.action.focusNextGroup')<CR>
-nnoremap <silent> <C-w><C-w> :<C-u>call VSCodeNotify('workbench.action.focusNextGroup')<CR>
-xnoremap <silent> <C-w><C-w> :<C-u>call VSCodeNotify('workbench.action.focusNextGroup')<CR>
-nnoremap <silent> <C-w>W :<C-u>call VSCodeNotify('workbench.action.focusPreviousGroup')<CR>
-xnoremap <silent> <C-w>W :<C-u>call VSCodeNotify('workbench.action.focusPreviousGroup')<CR>
-nnoremap <silent> <C-w>p :<C-u>call VSCodeNotify('workbench.action.focusPreviousGroup')<CR>
-xnoremap <silent> <C-w>p :<C-u>call VSCodeNotify('workbench.action.focusPreviousGroup')<CR>
-nnoremap <silent> <C-w>t :<C-u>call VSCodeNotify('workbench.action.focusFirstEditorGroup')<CR>
-xnoremap <silent> <C-w>t :<C-u>call VSCodeNotify('workbench.action.focusFirstEditorGroup')<CR>
-nnoremap <silent> <C-w>b :<C-u>call VSCodeNotify('workbench.action.focusLastEditorGroup')<CR>
-xnoremap <silent> <C-w>b :<C-u>call VSCodeNotify('workbench.action.focusLastEditorGroup')<CR>
+nnoremap <silent> <C-w>j <Cmd>call VSCodeNotify('workbench.action.focusBelowGroup')<CR>
+xnoremap <silent> <C-w>j <Cmd>call VSCodeNotify('workbench.action.focusBelowGroup')<CR>
+nnoremap <silent> <C-w><C-j> <Cmd>call VSCodeNotify('workbench.action.moveEditorToBelowGroup')<CR>
+xnoremap <silent> <C-w><C-j> <Cmd>call VSCodeNotify('workbench.action.moveEditorToBelowGroup')<CR>
+nnoremap <silent> <C-w>k <Cmd>call VSCodeNotify('workbench.action.focusAboveGroup')<CR>
+xnoremap <silent> <C-w>k <Cmd>call VSCodeNotify('workbench.action.focusAboveGroup')<CR>
+nnoremap <silent> <C-w><C-i> <Cmd>call VSCodeNotify('workbench.action.moveEditorToAboveGroup')<CR>
+xnoremap <silent> <C-w><C-i> <Cmd>call VSCodeNotify('workbench.action.moveEditorToAboveGroup')<CR>
+nnoremap <silent> <C-w>h <Cmd>call VSCodeNotify('workbench.action.focusLeftGroup')<CR>
+xnoremap <silent> <C-w>h <Cmd>call VSCodeNotify('workbench.action.focusLeftGroup')<CR>
+nnoremap <silent> <C-w><C-h> <Cmd>call VSCodeNotify('workbench.action.moveEditorToLeftGroup')<CR>
+xnoremap <silent> <C-w><C-h> <Cmd>call VSCodeNotify('workbench.action.moveEditorToLeftGroup')<CR>
+nnoremap <silent> <C-w>l <Cmd>call VSCodeNotify('workbench.action.focusRightGroup')<CR>
+xnoremap <silent> <C-w>l <Cmd>call VSCodeNotify('workbench.action.focusRightGroup')<CR>
+nnoremap <silent> <C-w><C-l> <Cmd>call VSCodeNotify('workbench.action.moveEditorToRightGroup')<CR>
+xnoremap <silent> <C-w><C-l> <Cmd>call VSCodeNotify('workbench.action.moveEditorToRightGroup')<CR>
+nnoremap <silent> <C-w>w <Cmd>call VSCodeNotify('workbench.action.focusNextGroup')<CR>
+xnoremap <silent> <C-w>w <Cmd>call VSCodeNotify('workbench.action.focusNextGroup')<CR>
+nnoremap <silent> <C-w><C-w> <Cmd>call VSCodeNotify('workbench.action.focusNextGroup')<CR>
+xnoremap <silent> <C-w><C-w> <Cmd>call VSCodeNotify('workbench.action.focusNextGroup')<CR>
+nnoremap <silent> <C-w>W <Cmd>call VSCodeNotify('workbench.action.focusPreviousGroup')<CR>
+xnoremap <silent> <C-w>W <Cmd>call VSCodeNotify('workbench.action.focusPreviousGroup')<CR>
+nnoremap <silent> <C-w>p <Cmd>call VSCodeNotify('workbench.action.focusPreviousGroup')<CR>
+xnoremap <silent> <C-w>p <Cmd>call VSCodeNotify('workbench.action.focusPreviousGroup')<CR>
+nnoremap <silent> <C-w>t <Cmd>call VSCodeNotify('workbench.action.focusFirstEditorGroup')<CR>
+xnoremap <silent> <C-w>t <Cmd>call VSCodeNotify('workbench.action.focusFirstEditorGroup')<CR>
+nnoremap <silent> <C-w>b <Cmd>call VSCodeNotify('workbench.action.focusLastEditorGroup')<CR>
+xnoremap <silent> <C-w>b <Cmd>call VSCodeNotify('workbench.action.focusLastEditorGroup')<CR>
 
-nnoremap <silent> <C-w>= :<C-u>call VSCodeNotify('workbench.action.evenEditorWidths')<CR>
-xnoremap <silent> <C-w>= :<C-u>call VSCodeNotify('workbench.action.evenEditorWidths')<CR>
+nnoremap <silent> <C-w>= <Cmd>call VSCodeNotify('workbench.action.evenEditorWidths')<CR>
+xnoremap <silent> <C-w>= <Cmd>call VSCodeNotify('workbench.action.evenEditorWidths')<CR>
 
-nnoremap <silent> <C-w>> :<C-u>call <SID>manageEditorSize(v:count, 'increase')<CR>
-xnoremap <silent> <C-w>> :<C-u>call <SID>manageEditorSize(v:count, 'increase')<CR>
-nnoremap <silent> <C-w>+ :<C-u>call <SID>manageEditorSize(v:count, 'increase')<CR>
-xnoremap <silent> <C-w>+ :<C-u>call <SID>manageEditorSize(v:count, 'increase')<CR>
-nnoremap <silent> <C-w>< :<C-u>call <SID>manageEditorSize(v:count, 'decrease')<CR>
-xnoremap <silent> <C-w>< :<C-u>call <SID>manageEditorSize(v:count, 'decrease')<CR>
-nnoremap <silent> <C-w>- :<C-u>call <SID>manageEditorSize(v:count, 'decrease')<CR>
-xnoremap <silent> <C-w>- :<C-u>call <SID>manageEditorSize(v:count, 'decrease')<CR>
+nnoremap <silent> <C-w>> <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
+xnoremap <silent> <C-w>> <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
+nnoremap <silent> <C-w>+ <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
+xnoremap <silent> <C-w>+ <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
+nnoremap <silent> <C-w>< <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
+xnoremap <silent> <C-w>< <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
+nnoremap <silent> <C-w>- <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
+xnoremap <silent> <C-w>- <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
 
-nnoremap <silent> <C-w>_ :<C-u>call VSCodeNotify('workbench.action.toggleEditorWidths')<CR>
+nnoremap <silent> <C-w>_ <Cmd>call VSCodeNotify('workbench.action.toggleEditorWidths')<CR>
 
-nnoremap <C-w>H :<C-u>echoerr 'Not supported yet'<CR>
-xnoremap <C-w>H :<C-u>echoerr 'Not supported yet'<CR>
-nnoremap <C-w>L :<C-u>echoerr 'Not supported yet'<CR>
-xnoremap <C-w>L :<C-u>echoerr 'Not supported yet'<CR>
-nnoremap <C-w>K :<C-u>echoerr 'Not supported yet'<CR>
-xnoremap <C-w>K :<C-u>echoerr 'Not supported yet'<CR>
-nnoremap <C-w>J :<C-u>echoerr 'Not supported yet'<CR>
-xnoremap <C-w>J :<C-u>echoerr 'Not supported yet'<CR>
+nnoremap <C-w>H <Cmd>echoerr 'Not supported yet'<CR>
+xnoremap <C-w>H <Cmd>echoerr 'Not supported yet'<CR>
+nnoremap <C-w>L <Cmd>echoerr 'Not supported yet'<CR>
+xnoremap <C-w>L <Cmd>echoerr 'Not supported yet'<CR>
+nnoremap <C-w>K <Cmd>echoerr 'Not supported yet'<CR>
+xnoremap <C-w>K <Cmd>echoerr 'Not supported yet'<CR>
+nnoremap <C-w>J <Cmd>echoerr 'Not supported yet'<CR>
+xnoremap <C-w>J <Cmd>echoerr 'Not supported yet'<CR>


### PR DESCRIPTION
I believe this was suggested by @Shatur95 in another issue.

A command exists called `<Cmd>` that replaces the need for `:<C-U>` and `gv` in mappings that call commands.

In brief: (`help :map-cmd`),
> The <Cmd> pseudokey begins a "command mapping", which executes the command
directly (without changing modes).
This is more flexible than `:<C-U>` in visual and operator-pending mode, or
`<C-O>:` in insert-mode, because the commands are executed directly in the
current mode (instead of always going to normal-mode).  Visual-mode is
preserved, so tricks with |gv| are not needed.  Commands can be invoked
directly in cmdline-mode (which would otherwise require timer hacks).

I did a search and replace for this over the whole project, as well as removed all the unnecessary `gv` commands and even entirely removed some helper functions.

Finally, there is this note in the help txt:
> Because <Cmd> avoids mode-changes (unlike ":") it does not trigger CmdlineEnter and CmdlineLeave events. This helps performance.

When testing out this PR, I've noticed an improvement in editor responsiveness and speed!