### PR TITLE
Remove <C-w>gf command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Neovim 0.5.0-nightly or greater
 -   `gf` is mapped to `editor.action.revealDeclaration`
 -   `gH` is mapped to `editor.action.referenceSearch.trigger`
 -   `gD`/`gF` are mapped to `editor.action.peekDefinition` and `editor.action.peekDeclaration` respectively (opens in peek)
--   `<C-w>gd`/`<C-w>gf` are mapped to `editor.action.revealDefinitionAside` and `editor.action.revealDeclarationAside` respectively (original vim command - open new tab and go to the file under cursor, but vscode/vim window/tabs metaphors are completely different, so it's useful to do slightly different thing here)
+-   `<C-w>gd`/`<C-w>gf` are mapped to `editor.action.revealDefinitionAside` (original vim command - open new tab and go to the file under cursor, but vscode/vim window/tabs metaphors are completely different, so it's useful to do slightly different thing here)
 -   `gh` is mapped to `editor.action.showHover`
 -   Dot-repeat (`.`) . Works starting from `0.0.52` version. Moving cursor within a change range won't break the repeat sequence. I.e. in neovim, if you type `abc<cursor>` in insert mode then move cursor to `a<cursor>bc` and type `1` here the repeat sequence would be `1`. However in vscode it would be `a1bc`. Another difference that `.` repeat command when you delete some text only works from right-to-left. I.e. it will treat `<Del>` key as `<BS>` keys for dot repeat.
 -   Outline navigation doesn't create jumpoints

--- a/vim/vscode-code-actions.vim
+++ b/vim/vscode-code-actions.vim
@@ -91,9 +91,9 @@ xnoremap <silent> gD :<C-u>call VSCodeNotify('editor.action.peekDefinition')<CR>
 xnoremap <silent> gH :<C-u>call VSCodeNotify('editor.action.referenceSearch.trigger')<CR>
 
 " <C-w> gf opens definition on the side
-nnoremap <silent> <C-w>gf :<C-u>call VSCodeNotify('editor.action.revealDeclarationAside')<CR>
+nnoremap <silent> <C-w>gf :<C-u>call VSCodeNotify('editor.action.revealDefinitionAside')<CR>
 nnoremap <silent> <C-w>gd :<C-u>call VSCodeNotify('editor.action.revealDefinitionAside')<CR>
-xnoremap <silent> <C-w>gf :<C-u>call VSCodeNotify('editor.action.revealDeclarationAside')<CR>
+xnoremap <silent> <C-w>gf :<C-u>call VSCodeNotify('editor.action.revealDefinitionAside')<CR>
 xnoremap <silent> <C-w>gd :<C-u>call VSCodeNotify('editor.action.revealDefinitionAside')<CR>
 
 " Bind C-/ to vscode commentary since calling from vscode produces double comments due to multiple cursors


### PR DESCRIPTION
Currently When you type `<C-w>gf`, it does not work because `editor.action. revealDeclarationAside ` does not exist in vscode.

![image](https://user-images.githubusercontent.com/18569016/93014923-0c90e500-f5f0-11ea-8711-f1d76b8f1ff4.png)