### PR TITLE
Map :x to Wq

### DIFF
--- a/vim/vscode-file-commands.vim
+++ b/vim/vscode-file-commands.vim
@@ -38,6 +38,7 @@ command! -bang Wall call VSCodeNotify('workbench.action.files.saveAll')
 command! -bang Quit if <q-bang> ==# '!' | call VSCodeNotify('workbench.action.revertAndCloseActiveEditor') | else | call VSCodeNotify('workbench.action.closeActiveEditor') | endif
 
 command! -bang Wq call <SID>saveAndClose()
+command! -bang Xit call <SID>saveAndClose()
 
 command! -bang Qall call VSCodeNotify('workbench.action.closeAllEditors')
 
@@ -53,7 +54,7 @@ AlterCommand sav[eas] Saveas
 AlterCommand wa[ll] Wall
 AlterCommand q[uit] Quit
 AlterCommand wq Wq
-AlterCommand x Wq
+AlterCommand x Xit
 AlterCommand qa[ll] Qall
 AlterCommand wqa[ll] Wqall
 AlterCommand xa[ll] Xall

--- a/vim/vscode-file-commands.vim
+++ b/vim/vscode-file-commands.vim
@@ -53,6 +53,7 @@ AlterCommand sav[eas] Saveas
 AlterCommand wa[ll] Wall
 AlterCommand q[uit] Quit
 AlterCommand wq Wq
+AlterCommand x Wq
 AlterCommand qa[ll] Qall
 AlterCommand wqa[ll] Wqall
 AlterCommand xa[ll] Xall

--- a/vim/vscode-file-commands.vim
+++ b/vim/vscode-file-commands.vim
@@ -54,7 +54,7 @@ AlterCommand sav[eas] Saveas
 AlterCommand wa[ll] Wall
 AlterCommand q[uit] Quit
 AlterCommand wq Wq
-AlterCommand x Xit
+AlterCommand x[it] Xit
 AlterCommand qa[ll] Qall
 AlterCommand wqa[ll] Wqall
 AlterCommand xa[ll] Xall


### PR DESCRIPTION
I often use :x to quickly save and close a file, but I noticed it was not mapped and caused issues where the extensions stopped working when a another file was opened.

xa is already implemented, so this is just for the single file save/close