### PR TITLE
Disable shada

### DIFF
--- a/vim/vscode-options.vim
+++ b/vim/vscode-options.vim
@@ -24,7 +24,7 @@ set bufhidden=hide
 " do not attempt autowrite any buffers
 set noautowrite
 " Disable shada session storing
-" set shada=
+set shada=
 " set nonumber
 set norelativenumber
 " Render line number as "marker" of the visible top/bottom screen row


### PR DESCRIPTION
This PR uncomments `set shada=` option. [Similar](https://github.com/VSCodeVim/Vim/pull/3288) approach used in VSCodeVim but with command-line arguments. Without this `v:oldfiles` will be filled with useless `file://...`.