### PR TITLE
Ignore WSL option on non windows OS

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     const mouseVisualSelection = settings.get("mouseSelectionStartVisualMode", false);
     const useCtrlKeysNormalMode = settings.get("useCtrlKeysForNormalMode", true);
     const useCtrlKeysInsertMode = settings.get("useCtrlKeysForInsertMode", true);
-    const useWsl = settings.get("useWSL", false) && isWindows;
+    const useWsl = isWindows && settings.get("useWSL", false);
     const revealCursorScrollLine = settings.get("revealCursorScrollLine", false);
     const neovimWidth = settings.get("neovimWidth", 1000);
     const customInit = getNeovimInitPath() ?? "";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,13 +13,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         vscode.window.showErrorMessage("Neovim: configure the path to neovim and restart the editor");
         return;
     }
+    const isWindows = process.platform == "win32";
+
     const highlightConfIgnore = settings.get("highlightGroups.ignoreHighlights");
     const highlightConfHighlights = settings.get("highlightGroups.highlights");
     const highlightConfUnknown = settings.get("highlightGroups.unknownHighlight");
     const mouseVisualSelection = settings.get("mouseSelectionStartVisualMode", false);
     const useCtrlKeysNormalMode = settings.get("useCtrlKeysForNormalMode", true);
     const useCtrlKeysInsertMode = settings.get("useCtrlKeysForInsertMode", true);
-    const useWsl = settings.get("useWSL", false);
+    const useWsl = settings.get("useWSL", false) && isWindows;
     const revealCursorScrollLine = settings.get("revealCursorScrollLine", false);
     const neovimWidth = settings.get("neovimWidth", 1000);
     const customInit = getNeovimInitPath() ?? "";


### PR DESCRIPTION
Using the node.js variable process.platform the platform node is running on can be found. If it isn't windows based then the wsl setting is set to false. 
Manually tested on windows 10 and a debian based OS. 

closes #381