### PR TITLE
Use column position when using Ctrl-A in insert

### DIFF
--- a/src/test/suite/insert-mode.test.ts
+++ b/src/test/suite/insert-mode.test.ts
@@ -487,14 +487,14 @@ describe("Insert mode and buffer syncronization", () => {
         await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
         await wait();
 
-        await sendVSCodeKeys("i1"); 
+        await sendVSCodeKeys("i1");
         await sendEscapeKey(1000);
-        await sendVSCodeKeys("a2"); 
+        await sendVSCodeKeys("a2");
         await sendEscapeKey(1000);
-        await sendVSCodeKeys("a3"); 
+        await sendVSCodeKeys("a3");
         await sendEscapeKey(1000);
-        await sendVSCodeKeys("a"); 
-        vscode.commands.executeCommand("vscode-neovim.ctrl-a-insert")
+        await sendVSCodeKeys("a");
+        vscode.commands.executeCommand("vscode-neovim.ctrl-a-insert");
         await wait();
 
         await sendEscapeKey(1000);

--- a/src/test/suite/insert-mode.test.ts
+++ b/src/test/suite/insert-mode.test.ts
@@ -481,4 +481,29 @@ describe("Insert mode and buffer syncronization", () => {
             client,
         );
     });
+
+    it("Handles repeating last inserted text", async () => {
+        const doc = await vscode.workspace.openTextDocument();
+        await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
+        await wait();
+
+        await sendVSCodeKeys("i1"); 
+        await sendEscapeKey(1000);
+        await sendVSCodeKeys("a2"); 
+        await sendEscapeKey(1000);
+        await sendVSCodeKeys("a3"); 
+        await sendEscapeKey(1000);
+        await sendVSCodeKeys("a"); 
+        vscode.commands.executeCommand("vscode-neovim.ctrl-a-insert")
+        await wait();
+
+        await sendEscapeKey(1000);
+
+        await assertContent(
+            {
+                content: ["1233"],
+            },
+            client,
+        );
+    });
 });

--- a/vim/vscode-neovim.vim
+++ b/vim/vscode-neovim.vim
@@ -83,15 +83,14 @@ endfunction
 
 " Used for ctrl-a insert keybinding
 function! VSCodeGetLastInsertText()
-    let line1 = line("'[")
-    let line2 = line("']")
-    if (line1 == 0)
+    let [lineStart, colStart] = getpos("'[")[1:2]
+    let [lineEnd, colEnd] = getpos("']")[1:2]
+    if (lineStart == 0)
         return []
     endif
-    let lines = []
-    for i in range(line1, line2)
-        call add(lines, getline(i))
-    endfor
+    let lines = getline(lineStart, lineEnd)
+    let lines[0] = lines[0][colStart - 1:]
+    let lines[-1] = lines[-1][:colEnd - 1]
     return lines
 endfunction
 


### PR DESCRIPTION
With this change using Ctrl-A in insert mode will take into account the column position as well. This means that only the newest insert gets pasted.

closes #283