### PR TITLE
Set vim cwd as vscode workspace

### DIFF
--- a/src/main_controller.ts
+++ b/src/main_controller.ts
@@ -107,6 +107,9 @@ export class MainController implements vscode.Disposable {
         const neovimSupportScriptPath = path.posix.join(extensionPath, "vim", "vscode-neovim.vim");
         const neovimOptionScriptPath = path.posix.join(extensionPath, "vim", "vscode-options.vim");
 
+        const workspaceFolder = vscode.workspace.workspaceFolders;
+        const cwd = workspaceFolder ? workspaceFolder[0].uri.fsPath : "~";
+
         const args = [
             "-N",
             "--embed",
@@ -116,6 +119,8 @@ export class MainController implements vscode.Disposable {
             // load support script before user config (to allow to rebind keybindings/commands)
             "--cmd",
             `source ${neovimSupportScriptPath}`,
+            "-c",
+            `cd ${cwd}`,
         ];
         if (settings.useWsl) {
             args.unshift(settings.neovimPath);


### PR DESCRIPTION
When the first file is opened, set vim cwd to the
current workspace folder root if one is open
else the home directory of the user(determined by '~').

The workspace folder is not set properly before the first file is opened, so the neovim 'c' flag does not work and 'cmd' is used.

Since extensions are reloaded when a new workspace is opened, the correct directory is set even when a new workspace is opened.

This change will make 'vim-fugitive' work.