### PR TITLE
fix(visiblerange): try to restore visiblerange after set cursorpos

### DIFF
--- a/src/cursor_manager.ts
+++ b/src/cursor_manager.ts
@@ -91,6 +91,8 @@ export class CursorManager
     }
 
     public handleRedrawBatch(batch: [string, ...unknown[]][]): void {
+        const activeEditorVisibleRanges = window.activeTextEditor?.visibleRanges;
+
         const winCursorsUpdates: Map<number, { line: number; col: number }> = new Map();
         for (const [name, ...args] of batch) {
             const firstArg = args[0] || [];
@@ -179,6 +181,17 @@ export class CursorManager
             }
         }
         winCursorsUpdates.clear();
+
+        if (!activeEditorVisibleRanges?.[0]) {
+            return;
+        }
+
+        this.logger.debug(
+            `${LOG_PREFIX}: found preserved visibleRange ${JSON.stringify(
+                activeEditorVisibleRanges,
+            )}, trying to restore`,
+        );
+        window.activeTextEditor?.revealRange(activeEditorVisibleRanges[0], TextEditorRevealType.AtTop);
     }
 
     /**


### PR DESCRIPTION
- closes #427

While this is not elegant solution, this PR attempt to address #427 as much. Before setting cursor position it try to preserve last known visible range of active document, then force set once after cursor position is set. It still slightly moves scroll position since revealing range based on line number - if scroll position is in between two lines, slight scroll can be observed.

I don't believe this is best approach - but this is one of daily workflow blockers for me, and having this seems better than nothing.

