### PR TITLE
Implement manageEditorHeight and manageEditorWidth

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -12,7 +12,7 @@ jobs:
             matrix:
                 # os: [macos-latest, ubuntu-latest, windows-latest]
                 # CI windows have some issues, i'm not sure why
-                os: [macos-latest, ubuntu-latest]
+                os: [macos-latest, ubuntu-20.04]
         runs-on: ${{ matrix.os }}
         steps:
             - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -375,6 +375,34 @@ _Note_: split size distribution is controlled by `workbench.editor.splitSizing` 
 
 -   Decrease editor width by (optional) count
 
+To use VSCode command 'Increase/decrease current view size'
+- `workbench.action.increaseViewSize`
+- `workbench.action.decreaseViewSize`
+<details>
+<summary>Copy this into init.vim</summary>
+
+    ```
+    function! s:manageEditorSize(...)
+        let count = a:1
+        let to = a:2
+        for i in range(1, count ? count : 1)
+            call VSCodeNotify(to ==# 'increase' ? 'workbench.action.increaseViewSize' : 'workbench.action.decreaseViewSize')
+        endfor
+    endfunction
+
+    " Sample keybindings. Note these override default keybindings mentioned above.
+    nnoremap <C-w>> <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
+    xnoremap <C-w>> <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
+    nnoremap <C-w>+ <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
+    xnoremap <C-w>+ <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
+    nnoremap <C-w>< <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
+    xnoremap <C-w>< <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
+    nnoremap <C-w>- <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
+    xnoremap <C-w>- <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
+    ```
+</details>
+<br>
+
 `<C-w> _`
 
 -   Toggle maximized editor size. Pressing again will restore the size

--- a/README.md
+++ b/README.md
@@ -381,7 +381,6 @@ To use VSCode command 'Increase/decrease current view size'
 <details>
 <summary>Copy this into init.vim</summary>
 
-    ```
     function! s:manageEditorSize(...)
         let count = a:1
         let to = a:2
@@ -399,7 +398,6 @@ To use VSCode command 'Increase/decrease current view size'
     xnoremap <C-w>< <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
     nnoremap <C-w>- <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
     xnoremap <C-w>- <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
-    ```
 </details>
 <br>
 

--- a/README.md
+++ b/README.md
@@ -359,13 +359,21 @@ _Note_: split size distribution is controlled by `workbench.editor.splitSizing` 
 
 -   Align all editors to have the same width
 
-`[count]<C-w> >` or `[count]<C-w> +`
+`[count]<C-w> +`
 
--   Increase editor size by count. Both width & height are increased since in vscode it's not possible to control individual width/height
+-   Increase editor height by (optional) count
 
-`[count]<C-w> <` or `[count]<C-w> -`
+`[count]<C-w> -`
 
--   Decrease editor size by count. Both width & height are increased since in vscode it's not possible to control individual width/height
+-   Decrease editor height by (optional) count
+
+`[count]<C-w> >`
+
+-   Increase editor width by (optional) count
+
+`[count]<C-w> <`
+
+-   Decrease editor width by (optional) count
 
 `<C-w> _`
 

--- a/vim/vscode-window-commands.vim
+++ b/vim/vscode-window-commands.vim
@@ -18,13 +18,29 @@ function! s:closeOtherEditors()
     call VSCodeNotify('workbench.action.closeOtherEditors')
 endfunction
 
-function! s:manageEditorSize(...)
+function! s:manageEditorHeight(...)
     let count = a:1
     let to = a:2
     for i in range(1, count ? count : 1)
-        call VSCodeNotify(to ==# 'increase' ? 'workbench.action.increaseViewSize' : 'workbench.action.decreaseViewSize')
+        call VSCodeNotify(to ==# 'increase' ? 'workbench.action.increaseViewHeight' : 'workbench.action.decreaseViewHeight')
     endfor
 endfunction
+
+function! s:manageEditorWidth(...)
+    let count = a:1
+    let to = a:2
+    for i in range(1, count ? count : 1)
+        call VSCodeNotify(to ==# 'increase' ? 'workbench.action.increaseViewWidth' : 'workbench.action.decreaseViewWidth')
+    endfor
+endfunction
+
+" function! s:manageEditorSize(...)
+"     let count = a:1
+"     let to = a:2
+"     for i in range(1, count ? count : 1)
+"         call VSCodeNotify(to ==# 'increase' ? 'workbench.action.increaseViewSize' : 'workbench.action.decreaseViewSize')
+"     endfor
+" endfunction
 
 command! -complete=file -nargs=? Split call <SID>split('h', <q-args>)
 command! -complete=file -nargs=? Vsplit call <SID>split('v', <q-args>)
@@ -87,14 +103,23 @@ xnoremap <C-w>b <Cmd>call VSCodeNotify('workbench.action.focusLastEditorGroup')<
 nnoremap <C-w>= <Cmd>call VSCodeNotify('workbench.action.evenEditorWidths')<CR>
 xnoremap <C-w>= <Cmd>call VSCodeNotify('workbench.action.evenEditorWidths')<CR>
 
-nnoremap <C-w>> <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
-xnoremap <C-w>> <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
-nnoremap <C-w>+ <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
-xnoremap <C-w>+ <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
-nnoremap <C-w>< <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
-xnoremap <C-w>< <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
-nnoremap <C-w>- <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
-xnoremap <C-w>- <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
+nnoremap <C-w>+ <Cmd>call <SID>manageEditorHeight(v:count, 'increase')<CR>
+xnoremap <C-w>+ <Cmd>call <SID>manageEditorHeight(v:count, 'increase')<CR>
+nnoremap <C-w>- <Cmd>call <SID>manageEditorHeight(v:count, 'decrease')<CR>
+xnoremap <C-w>- <Cmd>call <SID>manageEditorHeight(v:count, 'decrease')<CR>
+nnoremap <C-w>> <Cmd>call <SID>manageEditorWidth(v:count,  'increase')<CR>
+xnoremap <C-w>> <Cmd>call <SID>manageEditorWidth(v:count,  'increase')<CR>
+nnoremap <C-w>< <Cmd>call <SID>manageEditorWidth(v:count,  'decrease')<CR>
+xnoremap <C-w>< <Cmd>call <SID>manageEditorWidth(v:count,  'decrease')<CR>
+
+" nnoremap <C-w>> <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
+" xnoremap <C-w>> <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
+" nnoremap <C-w>+ <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
+" xnoremap <C-w>+ <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
+" nnoremap <C-w>< <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
+" xnoremap <C-w>< <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
+" nnoremap <C-w>- <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
+" xnoremap <C-w>- <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
 
 nnoremap <C-w>_ <Cmd>call VSCodeNotify('workbench.action.toggleEditorWidths')<CR>
 

--- a/vim/vscode-window-commands.vim
+++ b/vim/vscode-window-commands.vim
@@ -104,33 +104,6 @@ xnoremap <C-w>> <Cmd>call <SID>manageEditorWidth(v:count,  'increase')<CR>
 nnoremap <C-w>< <Cmd>call <SID>manageEditorWidth(v:count,  'decrease')<CR>
 xnoremap <C-w>< <Cmd>call <SID>manageEditorWidth(v:count,  'decrease')<CR>
 
-" ----------------------------------------------------------------------------
-" Backup for VSCode command 'Increase/decrease current view size'
-" - workbench.action.increaseViewSize
-" - workbench.action.decreaseViewSize
-" To restore previous functionality, copy these commented out chunks into init.vim
-" ----------------------------------------------------------------------------
-
-" function! s:manageEditorSize(...)
-"     let count = a:1
-"     let to = a:2
-"     for i in range(1, count ? count : 1)
-"         call VSCodeNotify(to ==# 'increase' ? 'workbench.action.increaseViewSize' : 'workbench.action.decreaseViewSize')
-"     endfor
-" endfunction
-
-" nnoremap <C-w>> <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
-" xnoremap <C-w>> <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
-" nnoremap <C-w>+ <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
-" xnoremap <C-w>+ <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
-" nnoremap <C-w>< <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
-" xnoremap <C-w>< <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
-" nnoremap <C-w>- <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
-" xnoremap <C-w>- <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
-
-" ----------------------------------------------------------------------------
-
-
 nnoremap <C-w>_ <Cmd>call VSCodeNotify('workbench.action.toggleEditorWidths')<CR>
 
 nnoremap <C-w>H <Cmd>echoerr 'Not supported yet'<CR>

--- a/vim/vscode-window-commands.vim
+++ b/vim/vscode-window-commands.vim
@@ -34,14 +34,6 @@ function! s:manageEditorWidth(...)
     endfor
 endfunction
 
-" function! s:manageEditorSize(...)
-"     let count = a:1
-"     let to = a:2
-"     for i in range(1, count ? count : 1)
-"         call VSCodeNotify(to ==# 'increase' ? 'workbench.action.increaseViewSize' : 'workbench.action.decreaseViewSize')
-"     endfor
-" endfunction
-
 command! -complete=file -nargs=? Split call <SID>split('h', <q-args>)
 command! -complete=file -nargs=? Vsplit call <SID>split('v', <q-args>)
 command! -complete=file -nargs=? New call <SID>split('h', '__vscode_new__')
@@ -112,6 +104,21 @@ xnoremap <C-w>> <Cmd>call <SID>manageEditorWidth(v:count,  'increase')<CR>
 nnoremap <C-w>< <Cmd>call <SID>manageEditorWidth(v:count,  'decrease')<CR>
 xnoremap <C-w>< <Cmd>call <SID>manageEditorWidth(v:count,  'decrease')<CR>
 
+" ----------------------------------------------------------------------------
+" Backup for VSCode command 'Increase/decrease current view size'
+" - workbench.action.increaseViewSize
+" - workbench.action.decreaseViewSize
+" To restore previous functionality, copy these commented out chunks into init.vim
+" ----------------------------------------------------------------------------
+
+" function! s:manageEditorSize(...)
+"     let count = a:1
+"     let to = a:2
+"     for i in range(1, count ? count : 1)
+"         call VSCodeNotify(to ==# 'increase' ? 'workbench.action.increaseViewSize' : 'workbench.action.decreaseViewSize')
+"     endfor
+" endfunction
+
 " nnoremap <C-w>> <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
 " xnoremap <C-w>> <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
 " nnoremap <C-w>+ <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
@@ -120,6 +127,9 @@ xnoremap <C-w>< <Cmd>call <SID>manageEditorWidth(v:count,  'decrease')<CR>
 " xnoremap <C-w>< <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
 " nnoremap <C-w>- <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
 " xnoremap <C-w>- <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
+
+" ----------------------------------------------------------------------------
+
 
 nnoremap <C-w>_ <Cmd>call VSCodeNotify('workbench.action.toggleEditorWidths')<CR>
 


### PR DESCRIPTION
NOTE Breaking change.

* Implement `manageEditorHeight` and `manageEditorWidth` based on `help CTRL-W`

| Tag | Command  | Action in normal mode |
| ----------- | ----------- | ----------- | 
| CTRL-W_+ |	CTRL-W +	|   increase current window height N lines |
| CTRL-W_- |	CTRL-W -	|   decrease current window height N lines |
| CTRL-W_> |	CTRL-W >	|   increase current window width N columns |
| CTRL-W_< |	CTRL-W <	|   decrease current window width N columns |

* Keeping `manageEditorSize` and its keybindings commented-out as backup. This command increases/decreases both height & width of the active editor while also decreases/increases other windows (e.g. panel) all at the same time. To restore previous functionality of VSCode command 'Increase/decrease current view size': `workbench.action.increaseViewSize` and `workbench.action.decreaseViewSize`, copy this to init.vim https://github.com/asvetliakov/vscode-neovim/blob/39c46bdbedba2703d8bbbf87b68c8a40ba9a8306/vim/vscode-window-commands.vim#L107-L131

* Update README

# Test

`<C-W>+` 
`<C-W>-` 
`<C-W><` 
`<C-W>>` 

`5 <C-W>+` 
`5 <C-W>-` 
`5 <C-W><` 
`5 <C-W>>` 


![vscode-nvim](https://user-images.githubusercontent.com/54139483/101308228-7c380880-389d-11eb-84a9-a08ce657501c.gif)
