### PR TITLE
Replace deprecated neovimPath command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If you want to use WSL version of neovim, set `useWSL` configuration toggle and 
 
 Neovim 0.5.0-nightly or greater
 
--   Set neovim path in the extension settings and you're good to go. **Important** you must specify full path to neovim, like `C:\Neovim\bin\nvim.exe` or `/usr/local/bin/nvim`. **IMPORTANT 2:** the setting id is `vscode-neovim.neovimPath`
+-   Set neovim path in the extension settings and you're good to go. **Important** you must specify full path to neovim, like `C:\Neovim\bin\nvim.exe` or `/usr/local/bin/nvim`. **IMPORTANT 2:** the setting id is `vscode-neovim.neovimExecutablePaths.win32/linux/darwin`
 -   Tip: You can install neovim-0.5.0-nightly separately for just vscode, outside of your system's package manager installation
 
 ## Important


### PR DESCRIPTION
Upon using the `vscode-neovim.neovimPath` command in settings.json, you get a warning saying that the command has been deprecated and that you should utilize `vscode-neovim.neovimExecutablePaths.win32/linux/darwin`.

It's just a small fix in the README at the end of the day.