### PR TITLE
H M L keys: Fix bugs, add jumplists.

### DIFF
--- a/src/commands_controller.ts
+++ b/src/commands_controller.ts
@@ -51,6 +51,12 @@ export class CommandsController implements Disposable, NeovimExtensionRequestPro
             }
             case "move-cursor": {
                 const [to] = args as ["top" | "middle" | "bottom"];
+
+                // Fix bug: `goToLine` First moving to first character of the line before `goToLine` is triggered.
+                // Temporary solution: Move cursor to first character of the line and delay by 5 milliseconds before triggering `goToLine`. 1 millisecond delay failed manual tests.
+                vscode.commands.executeCommand("cursorHome");
+                await new Promise((resolve) => setTimeout(resolve, 5));
+
                 this.goToLine(to);
                 break;
             }

--- a/src/commands_controller.ts
+++ b/src/commands_controller.ts
@@ -51,11 +51,6 @@ export class CommandsController implements Disposable, NeovimExtensionRequestPro
             }
             case "move-cursor": {
                 const [to] = args as ["top" | "middle" | "bottom"];
-
-                // Fix bug: `goToLine` First moving to first character of the line before `goToLine` is triggered.
-                // Temporary solution: Move cursor to first character of the line
-                vscode.commands.executeCommand("cursorHome");
-
                 this.goToLine(to);
                 break;
             }

--- a/src/commands_controller.ts
+++ b/src/commands_controller.ts
@@ -53,9 +53,8 @@ export class CommandsController implements Disposable, NeovimExtensionRequestPro
                 const [to] = args as ["top" | "middle" | "bottom"];
 
                 // Fix bug: `goToLine` First moving to first character of the line before `goToLine` is triggered.
-                // Temporary solution: Move cursor to first character of the line and delay by 5 milliseconds before triggering `goToLine`. 1 millisecond delay failed manual tests.
+                // Temporary solution: Move cursor to first character of the line
                 vscode.commands.executeCommand("cursorHome");
-                await new Promise((resolve) => setTimeout(resolve, 5));
 
                 this.goToLine(to);
                 break;

--- a/vim/vscode-scrolling.vim
+++ b/vim/vscode-scrolling.vim
@@ -15,12 +15,19 @@ xnoremap z- <Cmd>call <SID>reveal('bottom', 1)<CR>
 nnoremap zb <Cmd>call <SID>reveal('bottom', 0)<CR>
 xnoremap zb <Cmd>call <SID>reveal('bottom', 0)<CR>
 
-nnoremap <expr> H VSCodeExtensionNotify('move-cursor', 'top')
-xnoremap <expr> H VSCodeExtensionNotify('move-cursor', 'top')
-nnoremap <expr> M VSCodeExtensionNotify('move-cursor', 'middle')
-xnoremap <expr> M VSCodeExtensionNotify('move-cursor', 'middle')
-nnoremap <expr> L VSCodeExtensionNotify('move-cursor', 'bottom')
-xnoremap <expr> L VSCodeExtensionNotify('move-cursor', 'bottom')
+
+function s:moveCursor(to)
+    " Native VSCode commands don't register jumplist. Fix by registering jumplist in Vim e.g. for subsequent use of <C-o>
+    normal! m'
+    call VSCodeExtensionNotify('move-cursor', a:to)
+endfunction
+
+nnoremap H <Cmd>call <SID>moveCursor('top')<CR>
+xnoremap H <Cmd>call <SID>moveCursor('top')<CR>
+nnoremap M <Cmd>call <SID>moveCursor('middle')<CR>
+xnoremap M <Cmd>call <SID>moveCursor('middle')<CR>
+nnoremap L <Cmd>call <SID>moveCursor('bottom')<CR>
+xnoremap L <Cmd>call <SID>moveCursor('bottom')<CR>
 
 " Disabled due to scroll problems (the ext binds them directly)
 " nnoremap <silent> <expr> <C-d> VSCodeExtensionCall('scroll', 'halfPage', 'down')


### PR DESCRIPTION
* Fix H M L keys first moving to first character of the line before it's triggered. Closes https://github.com/asvetliakov/vscode-neovim/issues/367
* Internally, H M L keys uses native VSCode commands, which don't register jumplist. Fix by registering jumplist in Vim e.g. for subsequent use of `<C-o>`

If you look at commit messages https://github.com/asvetliakov/vscode-neovim/commit/e67f5203ed8ec0bb958982a06c464e6758f4d54e, initially I added hacky fixes

```ts
case "move-cursor": {
    const [to] = args as ["top" | "middle" | "bottom"];

    // Fix bug: `goToLine` First moving to first character of the line before `goToLine` is triggered.
    // Temporary solution: Move cursor to first character of the line and delay by 5 milliseconds before triggering `goToLine`. 1 millisecond delay failed manual tests.
    vscode.commands.executeCommand("cursorHome");
    await new Promise((resolve) => setTimeout(resolve, 5));

    this.goToLine(to);
    break;
}
```

But after adding jumplists using Vim commands at https://github.com/asvetliakov/vscode-neovim/commit/c83dacd19f86cd7c572e28b9fbff1012958c21a2, which inherently has some milliseconds delays and it somehow magically fixes the bugs lol. So I remove the hacky fixes in the last commit https://github.com/asvetliakov/vscode-neovim/commit/39eb8a212cd4c9f61d21a571d80905e7b520c350. 

If possible, when merging this PR, please squash the commit messages for future references in case the bugs somehow come back. The bugs are still there but somehow adding jumplist made the bugs go away.

# Test

![fix_h_l_m_keys](https://user-images.githubusercontent.com/54139483/102301697-703dfc00-3fab-11eb-8e4b-37659cce6f00.gif)
