### PR TITLE
Add g0 g$ for normal mode

### DIFF
--- a/src/commands_controller.ts
+++ b/src/commands_controller.ts
@@ -54,6 +54,14 @@ export class CommandsController implements Disposable, NeovimExtensionRequestPro
                 this.goToLine(to);
                 break;
             }
+            case "cursor-move": {
+                const [to, by] = args as [
+                    "wrappedLineFirstNonWhitespaceCharacter" | "wrappedLineLastNonWhitespaceCharacter",
+                    "line" | "wrappedLine" | "character" | "halfLine",
+                ];
+                this.cursorMove(to, by);
+                break;
+            }
             case "scroll": {
                 const [by, to] = args as ["page" | "halfPage", "up" | "down"];
                 this.scrollPage(by, to);
@@ -136,6 +144,13 @@ export class CommandsController implements Disposable, NeovimExtensionRequestPro
                 line.firstNonWhitespaceCharacterIndex,
             ),
         ];
+    };
+
+    private cursorMove = (
+        to: "wrappedLineFirstNonWhitespaceCharacter" | "wrappedLineLastNonWhitespaceCharacter",
+        by: "line" | "wrappedLine" | "character" | "halfLine",
+    ): void => {
+        vscode.commands.executeCommand("cursorMove", { to: to, by: by, value: 1, select: false });
     };
 
     // zz, zt, zb and others

--- a/src/commands_controller.ts
+++ b/src/commands_controller.ts
@@ -54,14 +54,6 @@ export class CommandsController implements Disposable, NeovimExtensionRequestPro
                 this.goToLine(to);
                 break;
             }
-            case "cursor-move": {
-                const [to, by] = args as [
-                    "wrappedLineFirstNonWhitespaceCharacter" | "wrappedLineLastNonWhitespaceCharacter",
-                    "line" | "wrappedLine" | "character" | "halfLine",
-                ];
-                this.cursorMove(to, by);
-                break;
-            }
             case "scroll": {
                 const [by, to] = args as ["page" | "halfPage", "up" | "down"];
                 this.scrollPage(by, to);
@@ -144,13 +136,6 @@ export class CommandsController implements Disposable, NeovimExtensionRequestPro
                 line.firstNonWhitespaceCharacterIndex,
             ),
         ];
-    };
-
-    private cursorMove = (
-        to: "wrappedLineFirstNonWhitespaceCharacter" | "wrappedLineLastNonWhitespaceCharacter",
-        by: "line" | "wrappedLine" | "character" | "halfLine",
-    ): void => {
-        vscode.commands.executeCommand("cursorMove", { to: to, by: by, value: 1, select: false });
     };
 
     // zz, zt, zb and others

--- a/vim/vscode-motion.vim
+++ b/vim/vscode-motion.vim
@@ -1,0 +1,10 @@
+function! s:toLastCharOfScreenLine()
+    call VSCodeNotify('cursorEnd')
+    " Optmized delay is required after calling VSCode command
+    sleep 85m
+    " Offset cursor moving to the right by 1 column caused by calling `VSCodeNotify('cursorEnd')` in Vim mode
+    normal! h
+endfunction
+
+nnoremap g0 <Cmd>call VSCodeNotify('cursorHome')<CR>
+nnoremap g$ <Cmd>call <SID>toLastCharOfScreenLine()<CR>

--- a/vim/vscode-motion.vim
+++ b/vim/vscode-motion.vim
@@ -1,10 +1,12 @@
-function! s:toLastCharOfScreenLine()
-    call VSCodeNotify('cursorEnd')
-    " Optmized delay is required after calling VSCode command
-    sleep 85m
-    " Offset cursor moving to the right by 1 column caused by calling `VSCodeNotify('cursorEnd')` in Vim mode
-    normal! h
+function! s:toFirstCharOfScreenLine()
+    call VSCodeExtensionNotify('cursor-move', 'wrappedLineFirstNonWhitespaceCharacter')
 endfunction
 
-nnoremap g0 <Cmd>call VSCodeNotify('cursorHome')<CR>
+function! s:toLastCharOfScreenLine()
+    call VSCodeExtensionNotify('cursor-move', 'wrappedLineLastNonWhitespaceCharacter')
+    " Offfset cursor moving to the right caused by calling VSCode command in Vim mode
+    call VSCodeNotify('cursorLeft')
+endfunction
+
+nnoremap g0 <Cmd>call <SID>toFirstCharOfScreenLine()<CR>
 nnoremap g$ <Cmd>call <SID>toLastCharOfScreenLine()<CR>

--- a/vim/vscode-motion.vim
+++ b/vim/vscode-motion.vim
@@ -1,9 +1,9 @@
 function! s:toFirstCharOfScreenLine()
-    call VSCodeExtensionNotify('cursor-move', 'wrappedLineFirstNonWhitespaceCharacter')
+    call VSCodeNotify('cursorMove', { 'to': 'wrappedLineFirstNonWhitespaceCharacter' })
 endfunction
 
 function! s:toLastCharOfScreenLine()
-    call VSCodeExtensionNotify('cursor-move', 'wrappedLineLastNonWhitespaceCharacter')
+    call VSCodeNotify('cursorMove', { 'to': 'wrappedLineLastNonWhitespaceCharacter' })
     " Offfset cursor moving to the right caused by calling VSCode command in Vim mode
     call VSCodeNotify('cursorLeft')
 endfunction

--- a/vim/vscode-neovim.vim
+++ b/vim/vscode-neovim.vim
@@ -138,6 +138,7 @@ execute 'source ' . s:currDir . '/vscode-code-actions.vim'
 execute 'source ' . s:currDir . '/vscode-file-commands.vim'
 execute 'source ' . s:currDir . '/vscode-tab-commands.vim'
 execute 'source ' . s:currDir . '/vscode-window-commands.vim'
+execute 'source ' . s:currDir . '/vscode-motion.vim'
 
 augroup VscodeGeneral
     autocmd!


### PR DESCRIPTION
Add `g0` and `g$` for normal mode. (Partially?) Closes https://github.com/asvetliakov/vscode-neovim/issues/433

For other modes e.g. `vg0` `cg0`, they are not as straightforward due to e.g. 
* visual mode not producing the real VSCode selection
* delay between VSCode command and Vim command

I tried adding `vg0` `vg$`, playing around a bit but gave up. Kinda buggy. Might revisit in future. `g0` and `g$` covers some use cases for now.

# Test 

Start/end of screen line motion in normal mode
`g0`
`g$`
<br>

![add_g0_g$__v2](https://user-images.githubusercontent.com/54139483/102581702-34469a80-4155-11eb-93d0-caeb926d720b.gif)

