### PR TITLE
Refactor hl attrs to not override default colors

### DIFF
--- a/src/highlight_provider.ts
+++ b/src/highlight_provider.ts
@@ -42,11 +42,11 @@ function vimHighlightToVSCodeOptions(
     vimSpecialColor: string,
 ): ThemableDecorationRenderOptions {
     const options: ThemableDecorationRenderOptions = {};
-    // for absent color keys default color should be used
-    options.backgroundColor = uiAttrs.background
-        ? "#" + uiAttrs.background.toString(16)
-        : new ThemeColor("editor.background");
-    if(uiAttrs.foreground) {    
+    // for absent color keys color should not be changed
+    if (uiAttrs.background) {
+        options.backgroundColor = "#" + uiAttrs.background.toString(16);
+    }
+    if (uiAttrs.foreground) {
         options.color = "#" + uiAttrs.foreground.toString(16);
     }
     const specialColor = uiAttrs.special ? "#" + uiAttrs.special.toString(16) : vimSpecialColor;

--- a/src/highlight_provider.ts
+++ b/src/highlight_provider.ts
@@ -46,7 +46,9 @@ function vimHighlightToVSCodeOptions(
     options.backgroundColor = uiAttrs.background
         ? "#" + uiAttrs.background.toString(16)
         : new ThemeColor("editor.background");
-    options.color = uiAttrs.foreground ? "#" + uiAttrs.foreground.toString(16) : new ThemeColor("editor.foreground");
+    if(uiAttrs.foreground) {    
+        options.color = "#" + uiAttrs.foreground.toString(16);
+    }
     const specialColor = uiAttrs.special ? "#" + uiAttrs.special.toString(16) : vimSpecialColor;
 
     if (uiAttrs.reverse) {

--- a/src/highlight_provider.ts
+++ b/src/highlight_provider.ts
@@ -37,10 +37,7 @@ export interface HighlightConfiguration {
  * @param uiAttrs VIM UI attribute
  * @param vimSpecialColor Vim special color
  */
-function vimHighlightToVSCodeOptions(
-    uiAttrs: VimHighlightUIAttributes,
-    vimSpecialColor: string,
-): ThemableDecorationRenderOptions {
+function vimHighlightToVSCodeOptions(uiAttrs: VimHighlightUIAttributes): ThemableDecorationRenderOptions {
     const options: ThemableDecorationRenderOptions = {};
     // for absent color keys color should not be changed
     if (uiAttrs.background) {
@@ -49,7 +46,7 @@ function vimHighlightToVSCodeOptions(
     if (uiAttrs.foreground) {
         options.color = "#" + uiAttrs.foreground.toString(16);
     }
-    const specialColor = uiAttrs.special ? "#" + uiAttrs.special.toString(16) : vimSpecialColor;
+    const specialColor = uiAttrs.special ? "#" + uiAttrs.special.toString(16) : "";
 
     if (uiAttrs.reverse) {
         options.backgroundColor = new ThemeColor("editor.foreground");
@@ -145,7 +142,6 @@ export class HighlightProvider {
 
     private configuration: HighlightConfiguration;
 
-    private specialColor = "orange";
     /**
      * Set of ignored HL group ids. They can still be used with force flag (mainly for statusbar color decorations)
      */
@@ -208,7 +204,7 @@ export class HighlightProvider {
             return;
         } else {
             const options = this.configuration.highlights[name] || this.configuration.unknownHighlight;
-            const conf = options === "vim" ? vimHighlightToVSCodeOptions(vimUiAttrs, this.specialColor) : options;
+            const conf = options === "vim" ? vimHighlightToVSCodeOptions(vimUiAttrs) : options;
             this.createDecoratorForHighlightGroup(name, conf);
         }
     }


### PR DESCRIPTION
If the foreground or background colour keys are not specified, the plugin forcefully sets the colours to be the theme's default foreground/background colours. This means that if the text colour was changed by syntax hl, then it would become white. 

This is useful for underlining something without changing the colour - notably for use with `quick-scope` or `vim-current-word`:
```vim
  highlight QuickScopePrimary guifg=NONE guisp='#afff5f' gui=underline ctermfg=NONE cterm=underline
  highlight QuickScopeSecondary guifg=NONE guisp='#5fffff' gui=underline ctermfg=NONE cterm=underline
```

![image](https://user-images.githubusercontent.com/16546293/103337070-e83a0680-4a2e-11eb-8180-38520d002910.png)

Hopefully this does not cause any problems! I'm lucky to have figured this out :slightly_smiling_face: 

Do you think the above snippet should be added to the readme?

Finally, do you think the default underline "vimSpecialColor" should be changed to something more neutral, like the foreground colour?

Another quick thought, further down for the "reverse" attr, should the colours be read then inverted from the colour keys instead of just default foreground/background colour?