### PR TITLE
Cursor updates

### DIFF
--- a/src/cursor_manager.ts
+++ b/src/cursor_manager.ts
@@ -458,15 +458,18 @@ export class CursorManager
         if (Math.abs(deltaLine) <= 1) {
             this.logger.debug(`${LOG_PREFIX}: Editor: ${editorName} using cursorMove command`);
             if (Math.abs(deltaLine) > 0) {
-                this.logger.debug(`${LOG_PREFIX}: Editor: ${editorName} Moving cursor by line: ${deltaLine}, char: 0`);
-                commands.executeCommand("cursorLineStart");
+                if (newCol !== currCursor.character) {
+                    deltaChar = newCol;
+                    commands.executeCommand("cursorLineStart");
+                } else {
+                    deltaChar = 0;
+                }
                 commands.executeCommand("cursorMove", {
                     to: deltaLine > 0 ? "down" : "up",
                     by: "line",
                     value: Math.abs(deltaLine),
                     select: false,
                 });
-                deltaChar = newCol;
             }
             if (Math.abs(deltaChar) > 0) {
                 if (Math.abs(deltaLine) > 0) {

--- a/src/cursor_manager.ts
+++ b/src/cursor_manager.ts
@@ -326,40 +326,54 @@ export class CursorManager
         this.updateCursorStyle(this.modeManager.currentMode);
     };
 
+    private onSelectionChanged = async (e: TextEditorSelectionChangeEvent): Promise<void> => {
+        if (this.modeManager.isInsertMode) {
+            return;
+        }
+        if (this.ignoreSelectionEvents) {
+            return;
+        }
+        const { textEditor, kind } = e;
+        this.logger.debug(`${LOG_PREFIX}: SelectionChanged`);
+
+        // ! Note: Unfortunately navigating from outline is Command kind, so we can't skip it :(
+        // if (kind === TextEditorSelectionChangeKind.Command) {
+        //     this.logger.debug(`${LOG_PREFIX}: Skipping command kind`);
+        //     return;
+        // }
+
+        // wait for possible layout updates first
+        this.logger.debug(`${LOG_PREFIX}: Waiting for possible layout completion operation`);
+        await this.bufferManager.waitForLayoutSync();
+        // wait for possible change document events
+        this.logger.debug(`${LOG_PREFIX}: Waiting for possible document change completion operation`);
+        await this.changeManager.getDocumentChangeCompletionLock(textEditor.document);
+        this.logger.debug(`${LOG_PREFIX}: Waiting done`);
+
+        const documentChange = this.changeManager.eatDocumentCursorAfterChange(textEditor.document);
+        const cursor = textEditor.selection.active;
+        if (documentChange && documentChange.line === cursor.line && documentChange.character === cursor.character) {
+            this.logger.debug(
+                `${LOG_PREFIX}: Skipping onSelectionChanged event since it was selection produced by doc change`,
+            );
+            return;
+        }
+
+        this.applySelectionChanged(textEditor, kind);
+    };
+
     // ! Need to debounce requests because setting cursor by consequence of neovim event will trigger this method
     // ! and cursor may go out-of-sync and produce a jitter
-    private onSelectionChanged = debounce(
-        async (e: TextEditorSelectionChangeEvent): Promise<void> => {
-            if (this.modeManager.isInsertMode) {
-                return;
-            }
-            if (this.ignoreSelectionEvents) {
-                return;
-            }
-            const { textEditor, kind, selections } = e;
-            this.logger.debug(`${LOG_PREFIX}: SelectionChanged`);
-
-            // ! Note: Unfortunately navigating from outline is Command kind, so we can't skip it :(
-            // if (kind === TextEditorSelectionChangeKind.Command) {
-            //     this.logger.debug(`${LOG_PREFIX}: Skipping command kind`);
-            //     return;
-            // }
-
-            // wait for possible layout updates first
-            this.logger.debug(`${LOG_PREFIX}: Waiting for possible layout completion operation`);
-            await this.bufferManager.waitForLayoutSync();
-            // wait for possible change document events
-            this.logger.debug(`${LOG_PREFIX}: Waiting for possible document change completion operation`);
-            await this.changeManager.getDocumentChangeCompletionLock(textEditor.document);
-            this.logger.debug(`${LOG_PREFIX}: Waiting done`);
-
+    private applySelectionChanged = debounce(
+        async (textEditor: TextEditor, kind: TextEditorSelectionChangeKind | undefined) => {
             const winId = this.bufferManager.getWinIdForTextEditor(textEditor);
-            const cursor = selections[0].active;
+            const cursor = textEditor.selection.active;
+            const selections = textEditor.selections;
 
             this.logger.debug(
-                `${LOG_PREFIX}: kind: ${kind}, WinId: ${winId}, cursor: [${cursor.line}, ${
+                `${LOG_PREFIX}: Applying changed selection, kind: ${kind}, WinId: ${winId}, cursor: [${cursor.line}, ${
                     cursor.character
-                }], isMultiSelection: ${selections.length > 1}`,
+                }], isMultiSelection: ${textEditor.selections.length > 1}`,
             );
             if (!winId) {
                 return;
@@ -371,12 +385,11 @@ export class CursorManager
             }
 
             if (
-                e.selections.length > 1 ||
-                (e.kind === TextEditorSelectionChangeKind.Mouse &&
-                    !e.selections[0].active.isEqual(e.selections[0].anchor)) ||
+                selections.length > 1 ||
+                (kind === TextEditorSelectionChangeKind.Mouse && !selections[0].active.isEqual(selections[0].anchor)) ||
                 this.modeManager.isVisualMode
             ) {
-                if (e.kind !== TextEditorSelectionChangeKind.Mouse || !this.settings.mouseSelectionEnabled) {
+                if (kind !== TextEditorSelectionChangeKind.Mouse || !this.settings.mouseSelectionEnabled) {
                     return;
                 } else {
                     const grid = this.bufferManager.getGridIdForWinId(winId);
@@ -384,7 +397,7 @@ export class CursorManager
                     const requests: [string, unknown[]][] = [];
                     if (!this.modeManager.isVisualMode && grid) {
                         // need to start visual mode from anchor char
-                        const firstPos = e.selections[0].anchor;
+                        const firstPos = selections[0].anchor;
                         const mouseClickPos = editorPositionToNeovimPosition(textEditor, firstPos);
                         this.logger.debug(
                             `${LOG_PREFIX}: Starting visual mode from: [${mouseClickPos[0]}, ${mouseClickPos[1]}]`,
@@ -396,11 +409,11 @@ export class CursorManager
                         ]);
                         requests.push(["nvim_input", ["v"]]);
                     }
-                    const lastSelection = e.selections.slice(-1)[0];
+                    const lastSelection = selections.slice(-1)[0];
                     if (!lastSelection) {
                         return;
                     }
-                    const cursorPos = editorPositionToNeovimPosition(e.textEditor, lastSelection.active);
+                    const cursorPos = editorPositionToNeovimPosition(textEditor, lastSelection.active);
                     this.logger.debug(
                         `${LOG_PREFIX}: Updating cursor pos in neovim, winId: ${winId}, pos: [${cursorPos[0]}, ${cursorPos[1]}]`,
                     );

--- a/src/cursor_manager.ts
+++ b/src/cursor_manager.ts
@@ -93,6 +93,38 @@ export class CursorManager
                 );
                 break;
             }
+            case "cursorCharMove": {
+                const [direction, count] = args as ["left" | "right", number];
+                const currentEditor = window.activeTextEditor;
+                if (!currentEditor) {
+                    return;
+                }
+                const currentCursor = currentEditor.selection.active;
+                const currLine = currentEditor.document.lineAt(currentCursor.line);
+                if (direction === "right") {
+                    // !vscode range is including trailing character, so reduce it by 1
+                    const endOfLineCharacter = currLine.range.end.character - 1;
+                    const charactersTillEol = endOfLineCharacter - currentCursor.character;
+                    const finalCount = count <= charactersTillEol ? count : charactersTillEol;
+                    if (finalCount > 0) {
+                        await commands.executeCommand("cursorMove", {
+                            to: direction,
+                            by: "character",
+                            value: finalCount,
+                        });
+                    }
+                } else {
+                    const finalCount = count <= currentCursor.character ? count : currentCursor.character;
+                    if (finalCount > 0) {
+                        await commands.executeCommand("cursorMove", {
+                            to: direction,
+                            by: "character",
+                            value: finalCount,
+                        });
+                    }
+                }
+                break;
+            }
         }
     }
 
@@ -416,7 +448,7 @@ export class CursorManager
                 await callAtomic(this.client, requests, this.logger, LOG_PREFIX);
             }
         },
-        50,
+        20,
         { leading: false, trailing: true },
     );
 

--- a/src/test/suite/insert-mode.test.ts
+++ b/src/test/suite/insert-mode.test.ts
@@ -453,8 +453,7 @@ describe("Insert mode and buffer syncronization", () => {
 
         await assertContent(
             {
-                // TODO: should be [0, 13]
-                cursor: [0, 12],
+                cursor: [0, 13],
                 content: ["blah1aaa blah2"],
             },
             client,

--- a/src/test/suite/undo.test.ts
+++ b/src/test/suite/undo.test.ts
@@ -79,6 +79,58 @@ describe("Undo", () => {
         );
     });
 
+    it("Undo points are correct after newlines", async () => {
+        const doc = await vscode.workspace.openTextDocument({
+            content: "some line\notherline",
+        });
+        await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
+        await wait();
+        await sendVSCodeKeys("jo");
+        await sendVSCodeKeys("blah\nblah");
+        await sendEscapeKey();
+
+        await assertContent(
+            {
+                content: ["some line", "otherline", "blah", "blah"],
+            },
+            client,
+        );
+
+        await sendVSCodeKeys("u");
+        await assertContent(
+            {
+                content: ["some line", "otherline"],
+            },
+            client,
+        );
+    });
+
+    it("Undo points are correct after newlines - 2", async () => {
+        const doc = await vscode.workspace.openTextDocument({
+            content: "",
+        });
+        await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
+        await wait();
+        await sendVSCodeKeys("i");
+        await sendVSCodeKeys("blah\notherblah");
+        await sendEscapeKey();
+
+        await assertContent(
+            {
+                content: ["blah", "otherblah"],
+            },
+            client,
+        );
+
+        await sendVSCodeKeys("u");
+        await assertContent(
+            {
+                content: [""],
+            },
+            client,
+        );
+    });
+
     it("Buffer is ok after undo and o", async () => {
         const doc = await vscode.workspace.openTextDocument({
             content: "a\nb",

--- a/vim/vscode-code-actions.vim
+++ b/vim/vscode-code-actions.vim
@@ -93,9 +93,5 @@ xnoremap <C-w>gd <Cmd>call VSCodeNotify('editor.action.revealDefinitionAside')<C
 xnoremap <expr> <C-/> <SID>vscodeCommentary()
 nnoremap <expr> <C-/> <SID>vscodeCommentary() . '_'
 
-" Workaround for gk/gj
-nnoremap gk <Cmd>call VSCodeCall('cursorMove', { 'to': 'up', 'by': 'wrappedLine', 'value': v:count ? v:count : 1 })<CR>
-nnoremap gj <Cmd>call VSCodeCall('cursorMove', { 'to': 'down', 'by': 'wrappedLine', 'value': v:count ? v:count : 1 })<CR>
-
 " workaround for calling command picker in visual mode
 xnoremap <C-P> <Cmd>call <SID>openVSCodeCommandsInVisualMode()<CR>

--- a/vim/vscode-motion.vim
+++ b/vim/vscode-motion.vim
@@ -10,3 +10,12 @@ endfunction
 
 nnoremap g0 <Cmd>call <SID>toFirstCharOfScreenLine()<CR>
 nnoremap g$ <Cmd>call <SID>toLastCharOfScreenLine()<CR>
+
+
+nnoremap gk <Cmd>call VSCodeNotify('cursorMove', { 'to': 'up', 'by': 'wrappedLine', 'value': v:count ? v:count : 1 })<CR>
+nnoremap gj <Cmd>call VSCodeNotify('cursorMove', { 'to': 'down', 'by': 'wrappedLine', 'value': v:count ? v:count : 1 })<CR>
+
+nnoremap l <Cmd>call VSCodeExtensionCall('cursorCharMove', 'right',  v:count ? v:count : 1)<CR>
+nnoremap h <Cmd>call VSCodeExtensionCall('cursorCharMove', 'left', v:count ? v:count : 1)<CR>
+nnoremap j <Cmd>call VSCodeNotify('cursorMove', { 'to': 'down', 'by': 'line', 'value': v:count ? v:count : 1 })<CR>
+nnoremap k <Cmd>call VSCodeNotify('cursorMove', { 'to': 'up', 'by': 'line', 'value': v:count ? v:count : 1 })<CR>

--- a/vim/vscode-motion.vim
+++ b/vim/vscode-motion.vim
@@ -15,7 +15,5 @@ nnoremap g$ <Cmd>call <SID>toLastCharOfScreenLine()<CR>
 nnoremap gk <Cmd>call VSCodeNotify('cursorMove', { 'to': 'up', 'by': 'wrappedLine', 'value': v:count ? v:count : 1 })<CR>
 nnoremap gj <Cmd>call VSCodeNotify('cursorMove', { 'to': 'down', 'by': 'wrappedLine', 'value': v:count ? v:count : 1 })<CR>
 
-nnoremap l <Cmd>call VSCodeExtensionCall('cursorCharMove', 'right',  v:count ? v:count : 1)<CR>
-nnoremap h <Cmd>call VSCodeExtensionCall('cursorCharMove', 'left', v:count ? v:count : 1)<CR>
 nnoremap j <Cmd>call VSCodeNotify('cursorMove', { 'to': 'down', 'by': 'line', 'value': v:count ? v:count : 1 })<CR>
 nnoremap k <Cmd>call VSCodeNotify('cursorMove', { 'to': 'up', 'by': 'line', 'value': v:count ? v:count : 1 })<CR>

--- a/vim/vscode-motion.vim
+++ b/vim/vscode-motion.vim
@@ -11,9 +11,6 @@ endfunction
 nnoremap g0 <Cmd>call <SID>toFirstCharOfScreenLine()<CR>
 nnoremap g$ <Cmd>call <SID>toLastCharOfScreenLine()<CR>
 
-
+" Note: Using these in macro will break it
 nnoremap gk <Cmd>call VSCodeNotify('cursorMove', { 'to': 'up', 'by': 'wrappedLine', 'value': v:count ? v:count : 1 })<CR>
 nnoremap gj <Cmd>call VSCodeNotify('cursorMove', { 'to': 'down', 'by': 'wrappedLine', 'value': v:count ? v:count : 1 })<CR>
-
-nnoremap j <Cmd>call VSCodeNotify('cursorMove', { 'to': 'down', 'by': 'line', 'value': v:count ? v:count : 1 })<CR>
-nnoremap k <Cmd>call VSCodeNotify('cursorMove', { 'to': 'up', 'by': 'line', 'value': v:count ? v:count : 1 })<CR>


### PR DESCRIPTION
~1. Bind `j/k` to VSCode's `cursorMove` command~ This breaks macros unfortunately
2. When cursor movement is within same line - set it directly rather than call `cursorMove` command. This has much better speed and doesn't create jumppoint if within same line

Solves same line movement in #495 