### PR TITLE
Refactor bindings and README

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -4,6 +4,7 @@ module.exports = {
     singleQuote: true,
     printWidth: 120,
     tabWidth: 4,
-    singleQuote: false
+    singleQuote: false,
+    proseWrap: "always"
 };
 

--- a/README.md
+++ b/README.md
@@ -379,6 +379,34 @@ Refer to vim manual for their use.
 | <kbd>Up</kbd>/<kbd>Down</kbd>   | Select next/prev suggestion (cannot be used for history). |
 | <kbd>Tab</kbd>                  | Select suggestion.                                        |
 
+### VSCode navigation bindings
+
+#### Explorer/list navigation:
+
+| Key                            | VSCode Command                  |
+| ------------------------------ | ------------------------------- |
+| <kbd>j</kbd>/<kbd>k</kbd>      | `list.focusDown/Up`             |
+| <kbd>h</kbd>/<kbd>l</kbd>      | `list.collapse/select`          |
+| <kbd>Enter</kbd>               | `list.select`                   |
+| <kbd>gg</kbd>                  | `list.focusFirst`               |
+| <kbd>G</kbd>                   | `list.focusLast`                |
+| <kbd>o</kbd>                   | `list.toggleExpand`             |
+| <kbd>C-U</kbd>/<kbd>D</kbd>    | `list.focusPageUp/Down`         |
+| <kbd>/</kbd>/<kbd>Escape</kbd> | `list.toggleKeyboardNavigation` |
+
+#### Explorer file manipulation:
+
+| Key          | VSCode Command        |
+| ------------ | --------------------- |
+| <kbd>r</kbd> | `renameFile`          |
+| <kbd>d</kbd> | `deleteFile`          |
+| <kbd>y</kbd> | `filesExplorer.copy`  |
+| <kbd>x</kbd> | `filesExplorer.cut`   |
+| <kbd>p</kbd> | `filesExplorer.paste` |
+| <kbd>v</kbd> | `explorer.openToSide` |
+| <kbd>a</kbd> | `explorer.newFile`    |
+| <kbd>A</kbd> | `explorer.newFolder`  |
+
 ### Custom keybindings
 
 Control keys which are not in the above tables are not sent to neovim (as they are usually useless with vscode).

--- a/README.md
+++ b/README.md
@@ -210,6 +210,26 @@ See gif in action:
 
 ![multicursors](/images/multicursor.gif)
 
+### Keyboard Quickfix
+
+By default, the quickfix menu can be opened using <kbd>z=</kbd> or <kbd>C-.</kbd>. However, it is currently [not possible](https://github.com/microsoft/vscode/issues/55111) to add mappings to the quickfix menu, so it can only be navigated with arrow keys. A [workaround vscode extension](https://marketplace.visualstudio.com/items?itemName=pascalsenn.keyboard-quickfix) has been made to use the quick open menu, which can be navigated with custom bindings.
+
+To use, install the [keyboard-quickfix](https://marketplace.visualstudio.com/items?itemName=pascalsenn.keyboard-quickfix) extension, and add to your keybindings.json:
+
+```jsonc
+{
+    "key": "ctrl+.",
+    "command": "keyboard-quickfix.openQuickFix",
+    "when": "editorHasCodeActionsProvider && editorTextFocus && !editorReadonly"
+},
+```
+
+and add to your init.vim:
+
+```vim
+nnoremap z= <Cmd>call VSCodeNotify('keyboard-quickfix.openQuickFix')<CR>
+```
+
 ## Bindings
 
 **Custom keymaps for scrolling/window/tab/etc management**

--- a/README.md
+++ b/README.md
@@ -16,6 +16,40 @@ editor commands, making the best use of both editors.
 -   🥇 First-class and lag-free insert mode, letting VSCode do what it does best.
 -   🤝 Complete integration with VSCode features (lsp/autocompletion/snippets/multi-cursor/etc).
 
+<details>
+ <summary><strong>Table of Contents</strong> (click to expand)</summary>
+
+-   [🧰 Installation](#-installation)
+-   [💡 Tips and Features](#-tips-and-features)
+    -   [Important](#important)
+    -   [VSCode specific differences](#vscode-specific-differences)
+    -   [Performance problems](#performance-problems)
+    -   [Custom escape keys](#custom-escape-keys)
+    -   [Conditional init.vim](#conditional-initvim)
+    -   [Invoking VSCode actions from neovim](#invoking-vscode-actions-from-neovim)
+    -   [Jumplist](#jumplist)
+    -   [Wildmenu completion](#wildmenu-completion)
+    -   [Multiple cursors](#multiple-cursors)
+    -   [Keyboard Quickfix](#keyboard-quickfix)
+-   [⌨️ Bindings](#️-bindings)
+    -   [File/Tab management](#filetab-management)
+    -   [Buffer/window management](#bufferwindow-management)
+    -   [Insert mode special keys](#insert-mode-special-keys)
+    -   [Normal mode control keys](#normal-mode-control-keys)
+    -   [Cmdline control keys (always enabled)](#cmdline-control-keys-always-enabled)
+    -   [VSCode navigation bindings](#vscode-navigation-bindings)
+        -   [Explorer/list navigation](#explorerlist-navigation)
+        -   [Explorer file manipulation](#explorer-file-manipulation)
+    -   [Custom keybindings](#custom-keybindings)
+-   [🤝 Vim Plugins](#-vim-plugins)
+    -   [vim-easymotion](#vim-easymotion)
+    -   [vim-commentary](#vim-commentary)
+    -   [quick-scope](#quick-scope)
+-   [📑 How it works](#-how-it-works)
+-   [❤️ Credits & External Resources](#️-credits--external-resources)
+
+</details>
+
 ## 🧰 Installation
 
 -   Install the [vscode-neovim](https://marketplace.visualstudio.com/items?itemName=asvetliakov.vscode-neovim)
@@ -36,14 +70,15 @@ editor commands, making the best use of both editors.
 > that register `type` command (i.e. [VSCodeVim](https://marketplace.visualstudio.com/items?itemName=vscodevim.vim) or
 > [Overtype](https://marketplace.visualstudio.com/items?itemName=adammaras.overtype)).
 
-> 💡 If you already have a big `init.vim` it is recommended to wrap existing settings & plugins with
-> [`if !exists('g:vscode')`](#determining-if-running-in-vscode-in-your-initvim) to prevent potential conflicts. If you
-> have any problems, try with empty `init.vim` first.
+> 🐛 See the [issues section](https://github.com/asvetliakov/vscode-neovim/issues) for known issues.
 
-## Tips and Features
+## 💡 Tips and Features
 
 ### Important
 
+-   If you already have a big `init.vim` it is recommended to wrap existing settings & plugins with
+    [`if !exists('g:vscode')`](#determining-if-running-in-vscode-in-your-initvim) to prevent potential conflicts. If you
+    have any problems, try with empty `init.vim` first.
 -   Visual modes don't produce vscode selections, so any vscode commands expecting selection won't work. To round the
     corners, invoking the VSCode command picker from visual mode through the default hotkeys
     (<kbd>f1</kbd>/<kbd>ctrl/cmd+shift+p</kbd>) converts vim selection to real vscode selection. This conversion is done
@@ -59,7 +94,7 @@ editor commands, making the best use of both editors.
     This is normal.
 -   File/tab/window management (`:w`/`:q`/etc) commands are substituted and mapped to vscode actions. If you're using
     some custom commands/custom mappings to them, you might need to rebind them to call vscode actions instead. See
-    reference links below for examples if you want to use custom keybindings/commands. **DO NOT** use vim `:w`, etc in
+    reference links below for examples if you want to use custom keybindings/commands. **do not** use vim `:w`, etc in
     scripts/keybindings, they won't work.
 -   On a Mac, the <kbd>h</kbd>, <kbd>j</kbd>, <kbd>k</kbd> and <kbd>l</kbd> movement keys may not repeat when held, to
     fix this open Terminal and execute the following command:
@@ -273,7 +308,7 @@ and add to your init.vim:
 nnoremap z= <Cmd>call VSCodeNotify('keyboard-quickfix.openQuickFix')<CR>
 ```
 
-## Bindings
+## ⌨️ Bindings
 
 **Custom keymaps for scrolling/window/tab/etc management**
 
@@ -342,28 +377,29 @@ To use VSCode command 'Increase/decrease current view size' instead of separate 
 
 -   `workbench.action.increaseViewSize`
 -   `workbench.action.decreaseViewSize`
-    <details>
-    <summary>Copy this into init.vim</summary>
 
-        function! s:manageEditorSize(...)
-            let count = a:1
-            let to = a:2
-            for i in range(1, count ? count : 1)
-                call VSCodeNotify(to ==# 'increase' ? 'workbench.action.increaseViewSize' : 'workbench.action.decreaseViewSize')
-            endfor
-        endfunction
+<details>
+<summary>Copy this into init.vim</summary>
 
-        " Sample keybindings. Note these override default keybindings mentioned above.
-        nnoremap <C-w>> <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
-        xnoremap <C-w>> <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
-        nnoremap <C-w>+ <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
-        xnoremap <C-w>+ <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
-        nnoremap <C-w>< <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
-        xnoremap <C-w>< <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
-        nnoremap <C-w>- <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
-        xnoremap <C-w>- <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
+    function! s:manageEditorSize(...)
+        let count = a:1
+        let to = a:2
+        for i in range(1, count ? count : 1)
+            call VSCodeNotify(to ==# 'increase' ? 'workbench.action.increaseViewSize' : 'workbench.action.decreaseViewSize')
+        endfor
+    endfunction
 
-    </details>
+    " Sample keybindings. Note these override default keybindings mentioned above.
+    nnoremap <C-w>> <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
+    xnoremap <C-w>> <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
+    nnoremap <C-w>+ <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
+    xnoremap <C-w>+ <Cmd>call <SID>manageEditorSize(v:count, 'increase')<CR>
+    nnoremap <C-w>< <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
+    xnoremap <C-w>< <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
+    nnoremap <C-w>- <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
+    xnoremap <C-w>- <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
+
+</details>
 
 ### Insert mode special keys
 
@@ -396,7 +432,8 @@ Refer to vim manual for their use.
 -   <kbd>C-e</kbd>
 -   <kbd>C-f</kbd>
 -   <kbd>C-i</kbd>
--   <kbd>C-o</kbd> (see https://github.com/asvetliakov/vscode-neovim/issues/181#issuecomment-585264621)
+-   <kbd>C-o</kbd> (to enable, see
+    [this issue](https://github.com/asvetliakov/vscode-neovim/issues/181#issuecomment-585264621))
 -   <kbd>C-r</kbd>
 -   <kbd>C-u</kbd>
 -   <kbd>C-v</kbd>
@@ -425,7 +462,7 @@ Refer to vim manual for their use.
 
 ### VSCode navigation bindings
 
-#### Explorer/list navigation:
+#### Explorer/list navigation
 
 | Key                            | VSCode Command                  |
 | ------------------------------ | ------------------------------- |
@@ -438,7 +475,7 @@ Refer to vim manual for their use.
 | <kbd>C-u</kbd>/<kbd>C-d</kbd>  | `list.focusPageUp/Down`         |
 | <kbd>/</kbd>/<kbd>Escape</kbd> | `list.toggleKeyboardNavigation` |
 
-#### Explorer file manipulation:
+#### Explorer file manipulation
 
 | Key          | VSCode Command        |
 | ------------ | --------------------- |
@@ -477,11 +514,11 @@ To disable existing an ctrl key sequence, for example <kbd>C-A</kbd> add to your
 }
 ```
 
-## Vim Plugins
+## 🤝 Vim Plugins
 
 Most vim plugins will work out of the box, but certain plugins may require some fixes to work properly.
 
-### Vim-easymotion
+### vim-easymotion
 
 While the original [vim-easymotion](https://github.com/easymotion/vim-easymotion) functions as expected, it works by
 replacing your text with markers then restoring back, which leads to broken text and many errors reported in VSCode.
@@ -498,7 +535,7 @@ Happy jumping!
 
 ![easymotion](/images/easy-motion-vscode.png)
 
-### Vim-commentary
+### vim-commentary
 
 You can use [vim-commentary](https://github.com/tpope/vim-commentary) if you like it. But vscode already has such
 functionality so why don't use it? Add to your init.vim/init.nvim:
@@ -513,7 +550,7 @@ nmap gcc <Plug>VSCodeCommentaryLine
 Similar to vim-commentary, gcc is comment line (accept count), use gc with motion/in visual mode. `VSCodeCommentary` is
 just a simple function which calls `editor.action.commentLine`.
 
-### VIM quick-scope
+### quick-scope
 
 [quick-scope](https://github.com/unblevable/quick-scope) plugin uses default vim HL groups by default but they are
 normally ignored. To fix, add
@@ -525,11 +562,7 @@ highlight QuickScopeSecondary guifg='#5fffff' gui=underline ctermfg=81 cterm=und
 
 to your init.vim. The underline color can be changed by the `guisp` tag.
 
-## Known Issues
-
-See [Issues section](https://github.com/asvetliakov/vscode-neovim/issues).
-
-## How it works
+## 📑 How it works
 
 -   VScode connects to neovim instance
 -   When opening a some file, a scratch buffer is created in nvim and being init with text content from vscode
@@ -539,7 +572,7 @@ See [Issues section](https://github.com/asvetliakov/vscode-neovim/issues).
     (no neovim communication is being performed here)
 -   After pressing escape key from the insert mode, extension sends changes obtained from the insert mode to neovim
 
-## Credits & External Resources
+## ❤️ Credits & External Resources
 
 -   [vim-altercmd](https://github.com/kana/vim-altercmd) - Used for rebinding default commands to call vscode command
 -   [neovim nodejs client](https://github.com/neovim/node-client) - NodeJS library for communicating with Neovim

--- a/README.md
+++ b/README.md
@@ -1,66 +1,72 @@
-# Neo Vim (VS Code Neovim)
+<h2 align="center"><img src="./images/icon.png" height="128"><br>VSCode Neovim</h2>
+<p align="center"><strong>VSCode Neovim Integration</strong></p>
 
-Neovim integration for Visual Studio Code
+<p align=center>
+<a href="https://marketplace.visualstudio.com/items?itemName=asvetliakov.vscode-neovim"><img src="https://vsmarketplacebadge.apphb.com/version/asvetliakov.vscode-neovim.svg"></a>
+<a href="https://github.com/asvetliakov/vscode-neovim/actions/workflows/build_test.yml"><img src="https://github.com/asvetliakov/vscode-neovim/workflows/Code%20Check%20&%20Test/badge.svg"></a>
+<a href="https://gitter.im/vscode-neovim/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge"><img src="https://badges.gitter.im/vscode-neovim/community.svg"></a>
+</p>
 
-For those who don't know [Neovim](https://neovim.io/) is the fork of VIM to allow greater VIM extensibility and embeddability. The extension is using full embedded neovim instance as backend (with the exception of the insert mode and window/buffer/file management), no more half-complete VIM emulation
+Neovim integration for Visual Studio Code.
 
-Please report any issues/suggestions to [vscode-neovim repository](https://github.com/asvetliakov/vscode-neovim)
-
-[![Gitter](https://badges.gitter.im/vscode-neovim/community.svg)](https://gitter.im/vscode-neovim/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
-
-## Installation
-
--   Install [vscode-neovim](https://marketplace.visualstudio.com/items?itemName=asvetliakov.vscode-neovim) extension
--   Install [Neovim](https://github.com/neovim/neovim/wiki/Installing-Neovim) Required version **0.5.0 nightly** or greater
-    -   Tip: You can install neovim-0.5.0-nightly separately for just vscode, outside of your system's package manager installation
--   Set neovim path in the extension settings and you're good to go.
-    -   **Important** you must specify full path to neovim, like `C:\Neovim\bin\nvim.exe` or `/usr/local/bin/nvim`.
-    -   **IMPORTANT 2:** the setting id is `vscode-neovim.neovimExecutablePaths.win32/linux/darwin`
--   **Important!: If you already have big & custom `init.vim` i'd recommend to wrap existing settings & plugins with [`if !exists('g:vscode')`](#determining-if-running-in-vscode-in-your-initvim) check to prevent potential breakings and problems**. If you have any problems - try with empty `init.vim` first
-
-**Neovim 0.5+** is **required**. Any version lower than that won't work. Many linux distributions have an **old** version of neovim in their package repo - always check what version are you installing.
-
-If you get `Unable to init vscode-neovim: command 'type' already exists` message, try to uninstall other VSCode extensions, which register `type` command (i.e. [VSCodeVim](https://marketplace.visualstudio.com/items?itemName=vscodevim.vim) or [Overtype](https://marketplace.visualstudio.com/items?itemName=adammaras.overtype)).
-
-### WSL
-
-If you want to use WSL version of neovim, set `useWSL` configuration toggle and specify linux path to nvim binary. `wsl.exe` windows binary and `wslpath` linux binary are required for this. `wslpath` must be available through `$PATH` linux env setting. Use `wsl --list` to check for the correct default linux distribution.
+[Neovim](https://neovim.io/) is a fork of VIM to allow greater extensibility and integration. This extension uses a full embedded Neovim instance, no more half-complete VIM emulation! Control is given to VSCode for insert mode and window/buffer/file management, using the best of both editors.
 
 ## Features
 
--   Almost fully feature-complete VIM integration by utilizing neovim
--   First-class VSCode insert mode. The plugin unbinds self from the `type` event in the insert mode, so no typing lag and freezing anymore when long completion popup appears.
--   Fully working VSCode features - autocompletion/go to definition/snippets/multiple cursors/etc...
--   vimrc/vim plugins/etc are supported (few plugins don't make sense with vscode, such as nerdtree)
+-   Almost fully feature-complete VIM integration by utilizing neovim as a backend.
+-   Supports custom `init.vim` and many vim/neovim plugins.
+-   First-class VSCode insert mode. The plugin unbinds self from the `type` event in insert mode, so no more typing lag.
+-   Full integration with VSCode features - autocompletion/go to definition/snippets/multiple cursors/etc...
 
 ## Requirements
 
 Neovim 0.5.0-nightly or greater
 
-## Important
+## Installation
 
--   Visual modes are not producing real vscode selections (few versions had this feature previously, but it was implemented through ugly & hacky workarounds). Any vscode commands expecting selection won't work. To round the corners, invoking VSCode command picker through the default hotkeys (`f1`/`ctrl/cmd+shift+p`) from visual mode converts vim selection to real vscode selection. Also commenting/indenting/formatting works out of the box too. If you're using some custom mapping for calling vscode commands and depends on real vscode selection, you can use `VSCodeNotifyRange`/`VSCodeNotifyRangePos` (the first one linewise, the latter characterwise) functions which will convert visual mode selection to vscode selection before calling the command. See [this for example](https://github.com/asvetliakov/vscode-neovim/blob/e61832119988bb1e73b81df72956878819426ce2/vim/vscode-code-actions.vim#L42-L54) and [mapping](https://github.com/asvetliakov/vscode-neovim/blob/e61832119988bb1e73b81df72956878819426ce2/vim/vscode-code-actions.vim#L98)
+-   Install the [vscode-neovim](https://marketplace.visualstudio.com/items?itemName=asvetliakov.vscode-neovim) extension.
+-   Install [Neovim](https://github.com/neovim/neovim/wiki/Installing-Neovim) **0.5.0 nightly** or greater. You can install neovim-0.5.0-nightly separately for just vscode, outside your system's package manager installation.
+-   Set the neovim path in the extension settings. You must specify full path to neovim, like `"C:\Neovim\bin\nvim.exe"` or `"/usr/local/bin/nvim"`. The setting id is `"vscode-neovim.neovimExecutablePaths.win32/linux/darwin"`, depending on your system.
+-   **Important:** If you already have big `init.vim` it is recommended to wrap existing settings & plugins with [`if !exists('g:vscode')`](#determining-if-running-in-vscode-in-your-initvim) to prevent potential problems. If you have any problems, try with empty `init.vim` first.
+
+> :warning: **Neovim 0.5+** is **required**. Any version lower than that won't work. Many linux distributions have an **old** version of neovim in their package repo - always check what version are you installing.
+
+> :info: If you get `"Unable to init vscode-neovim: command 'type' already exists"` message, uninstall other VSCode extensions that register `type` command (i.e. [VSCodeVim](https://marketplace.visualstudio.com/items?itemName=vscodevim.vim) or [Overtype](https://marketplace.visualstudio.com/items?itemName=adammaras.overtype)).
+
+#### WSL
+
+If you want to use neovim from WSL, set `useWSL` configuration toggle and specify linux path to nvim binary. `wsl.exe` windows binary and `wslpath` linux binary are required for this. `wslpath` must be available through `$PATH` linux env setting. Use `wsl --list` to check for the correct default linux distribution.
+
+## Tips and Features
+
+### Important
+
+-   Visual modes don't produce real vscode selections. Any vscode commands expecting selection won't work. To round the corners, invoking the VSCode command picker from visual mode through the default hotkeys (`f1`/`ctrl/cmd+shift+p`) converts vim selection to real vscode selection. This conversion is done automatically for some commands like commenting and formatting.
+-   If you're using some custom mapping for calling vscode commands that depends on real vscode selection, you can use `VSCodeNotifyRange`/`VSCodeNotifyRangePos` (the first one linewise, the latter characterwise) functions which will convert visual mode selection to vscode selection before calling the command. See [this for example](https://github.com/asvetliakov/vscode-neovim/blob/e61832119988bb1e73b81df72956878819426ce2/vim/vscode-code-actions.vim#L42-L54) and [mapping](https://github.com/asvetliakov/vscode-neovim/blob/e61832119988bb1e73b81df72956878819426ce2/vim/vscode-code-actions.vim#L98).
 -   The extension for now works best if `editor.scrollBeyondLastLine` is disabled.
 -   When you type some commands they may be substituted for the another, like `:write` will be replaced by `:Write`. This is normal.
 -   File/tab/window management (`:w`/`q`/etc...) commands are substituted and mapped to vscode actions. If you're using some custom commands/custom mappings to them, you might need to rebind them to call vscode actions instead. See reference links below for examples if you want to use custom keybindings/commands. **DO NOT** use vim `:w`, etc... in scripts/keybindings, they won't work.
 -   On a Mac, the `h`, `j`, `k` and `l` movement keys may not repeat when held, to fix this open Terminal and execute the following command:
     `defaults write com.microsoft.VSCode ApplePressAndHoldEnabled -bool false`
 
-## VSCode specific features and differences
+### VSCode specific features and differences
 
 -   =, == are mapped to `editor.action.formatSelection`
--   It's possible to call vscode commands from neovim. See `VSCodeCall/VSCodeNotify` vim functions in `vscode-neovim.vim` file. `VSCodeCall` is blocking request, while `VSCodeNotify` is not (see below)
--   Scrolling is done by VSCode side. `<C-d>/<C-u>/etc...` are slightly different
--   File management commands such as `e` / `w` / `q` etc are mapped to corresponding vscode commands and behavior may be different (see below)
--   `gd`/`<C-]` are mapped to `editor.action.revealDefinition` (Shortcut `F12`), also `<C-]>` works in vim help files
+-   It's possible to call vscode commands from neovim. See `VSCodeCall/VSCodeNotify` vim functions in `vscode-neovim.vim` file. `VSCodeCall` is blocking request, while `VSCodeNotify` is not (see below).
+-   Scrolling is done by VSCode side. `<C-d>/<C-u>/etc...` are slightly different.
+-   File management commands such as `e` / `w` / `q` etc are mapped to corresponding vscode commands
+    and behavior may be different (see below).
+-   `gd`/`<C-]` are mapped to `editor.action.revealDefinition` (Shortcut `F12`), also `<C-]>` works
+    in vim help files.
 -   `gf` is mapped to `editor.action.revealDeclaration`
 -   `gH` is mapped to `editor.action.referenceSearch.trigger`
--   `gD`/`gF` are mapped to `editor.action.peekDefinition` and `editor.action.peekDeclaration` respectively (opens in peek)
--   `<C-w>gd`/`<C-w>gf` are mapped to `editor.action.revealDefinitionAside` (original vim command - open new tab and go to the file under cursor, but vscode/vim window/tabs metaphors are completely different, so it's useful to do slightly different thing here)
+-   `gD`/`gF` are mapped to `editor.action.peekDefinition` and `editor.action.peekDeclaration` respectively (opens in peek).
+-   `<C-w>gd`/`<C-w>gf` are mapped to `editor.action.revealDefinitionAside` (original vim command -
+    open new tab and go to the file under cursor, but vscode/vim window/tabs metaphors are completely different, so it's useful to do slightly different thing here).
 -   `gh` is mapped to `editor.action.showHover`
--   Dot-repeat (`.`) . Works starting from `0.0.52` version. Moving cursor within a change range won't break the repeat sequence. I.e. in neovim, if you type `abc<cursor>` in insert mode then move cursor to `a<cursor>bc` and type `1` here the repeat sequence would be `1`. However in vscode it would be `a1bc`. Another difference that `.` repeat command when you delete some text only works from right-to-left. I.e. it will treat `<Del>` key as `<BS>` keys for dot repeat.
+-   Dot-repeat (`.`). Moving cursor within a change range won't break the repeat sequence. I.e. in neovim, if you type `abc<cursor>` in insert mode then move cursor to `a<cursor>bc` and type `1` here the repeat sequence would be `1`. However in vscode it would be `a1bc`. Another difference that `.` repeat command when you delete some text only works from right-to-left. I.e. it will treat `<Del>` key as `<BS>` keys for dot repeat.
 
-## Performance/Latency problems
+### Performance/Latency problems
 
 If you have any performance problems (cursor jitter usually) make sure you're not using these kinds of extensions:
 
@@ -68,16 +74,17 @@ If you have any performance problems (cursor jitter usually) make sure you're no
 -   Indent guide extensions (VSCode has built-in indent guides)
 -   Brackets highlighter extensions (VSCode has built-in feature)
 -   Anything that renders decorators/put something into vscode gutter very often, e.g. on each cursor/line move
+-   VSCode extensions that delay the extension host like "Bracket Pair Colorizer"
 
 Such extension may be fine and work well, but combined with any extension which should control the cursor position (such as any vim extension) it may work very bad, due to shared vscode extension host between all extensions (E.g. one extension is taking the control over the host and blocking the other extension, this produces jitter).
 
 If you're not sure, disable all other extensions except mine, **reload vscode/window** and see if the problem persist before reporting.
 
-Also there are a reports that some vim settings/vim plugins increase latency and causing performance problems. Make sure you've disabled unneeded plugins. Many of them don't make sense with vscode and may cause any sort of problems. You don't need any code, highlighting, completion, lsp plugins as well any plugins that spawn windows/buffers (nerdtree and similar), fuzzy-finders plugins, etc. You might want to keep navigation/text-objects/text-editing/etc plugins - they should be fine.
+Also there are reports that some vim settings/vim plugins increase latency and cause performance problems. Make sure you've disabled unneeded plugins. Many of them don't make sense with vscode and may cause problems. You don't need any code, highlighting, completion, lsp plugins as well any plugins that spawn windows/buffers (nerdtree and similar), fuzzy-finders plugins, etc. You might want to keep navigation/text-objects/text-editing/etc plugins - they should be fine.
 
-## Enabling jj or jk as escape keys from the insert mode
+### Enabling jj or jk as escape keys from the insert mode
 
-Put into your keybindings.json:
+Since VSCode is responsible for insert mode, custom insert-mode vim mappings don't work. To map composite escape keys, put into your keybindings.json:
 
 for `jj`
 
@@ -101,7 +108,7 @@ to enable `jk` add also:
 }
 ```
 
-## Determining if running in vscode in your init.vim
+### Determining if running in vscode in your init.vim
 
 This should do the trick:
 
@@ -113,21 +120,22 @@ else
 endif
 ```
 
-## Invoking vscode actions from neovim
+### Invoking vscode actions from neovim
 
 There are [few helper functions](https://github.com/asvetliakov/vscode-neovim/blob/ecd361ff1968e597e2500e8ce1108830e918cfb8/vim/vscode-neovim.vim#L17-L39) that could be used to invoke any vscode commands:
 
--   `VSCodeNotify(command, ...)`/`VSCodeCall(command, ...)` - invokes vscode command with optional arguments
--   `VSCodeNotifyRange(command, line1, line2, leaveSelection ,...)`/`VSCodeCallRange(command, line1, line2, leaveSelection, ...)` - produces real vscode selection from line1 to line2 and invokes vscode command. Linewise. Put 1 for `leaveSelection` argument to leave vscode selection after invoking the command
--   `VSCodeNotifyRangePos(command, line1, line2, pos1, pos2, leaveSelection ,...)`/`VSCodeCallRangePos(command, line1, line2, pos1, pos2, leaveSelection, ...)` - produces real vscode selection from line1.pos1 to line2.pos2 and invokes vscode command. Characterwise
+-   `VSCodeNotify(command, ...)`/`VSCodeCall(command, ...)` - invokes vscode command with optional
+    arguments.
+-   `VSCodeNotifyRange(command, line1, line2, leaveSelection ,...)`/`VSCodeCallRange(command, line1, line2, leaveSelection, ...)` - produces real vscode selection from line1 to line2 and invokes vscode command. Linewise. Put 1 for `leaveSelection` argument to leave vscode selection after invoking the command.
+-   `VSCodeNotifyRangePos(command, line1, line2, pos1, pos2, leaveSelection ,...)`/`VSCodeCallRangePos(command, line1, line2, pos1, pos2, leaveSelection, ...)` - produces real vscode selection from line1.pos1 to line2.pos2 and invokes vscode command. Characterwise.
 
-Functions with `Notify` in name are non-blocking, the ones with `Call` are blocking. Generally **use Notify** unless you really need a blocking call
+Functions with `Notify` in name are non-blocking, the ones with `Call` are blocking. Generally **use Notify** unless you really need a blocking call.
 
 _Examples_:
 
 Produce linewise selection and show vscode commands (default binding)
 
-```
+```vim
 function! s:showCommands()
     let startLine = line("v")
     let endLine = line(".")
@@ -139,7 +147,7 @@ xnoremap <silent> <C-P> <Cmd>call <SID>showCommands()<CR>
 
 Produce characterwise selection and show vscode commands (default binding):
 
-```
+```vim
 function! s:showCommands()
     let startPos = getpos("v")
     let endPos = getpos(".")
@@ -151,27 +159,27 @@ xnoremap <silent> <C-P> <Cmd>call <SID>showCommands()<CR>
 
 Run Find in files for word under cursor in vscode:
 
-```
+```vim
 nnoremap <silent> ? <Cmd>call VSCodeNotify('workbench.action.findInFiles', { 'query': expand('<cword>')})<CR>
 ```
 
 Open definition aside (default binding):
 
-```
+```vim
 nnoremap <silent> <C-w>gd <Cmd>call VSCodeNotify('editor.action.revealDefinitionAside')<CR>
 ```
 
-## Jumplist
+### Jumplist
 
-VSCode's jumplist is being used. Make sure to bind to `workbench.action.navigateBack` / `workbench.action.navigateForward` if you're using custom mappings. Marks (both upper & lowercased) should be fine
+VSCode's jumplist is used instead of Neovim's. This is to make navigation caused by VSCode (mouse click, outline navigation, jump to definition, ect) be navigable. Make sure to bind to `workbench.action.navigateBack` / `workbench.action.navigateForward` if you're using custom mappings. Marks (both upper & lowercased) should be fine.
 
-## Wildmenu completion
+### Wildmenu completion
 
 Command menu has the wildmenu completion on type. The completion options appear after 1.5s (to not bother you when you write `:w` or `:noh`). `<Up>/<Down>` selects the option and `<Tab>` accepts it. See the gif:
 
 ![wildmenu](/images/wildmenu.gif)
 
-## Multiple cursors
+### Multiple cursors
 
 Multiple cursors work in:
 
@@ -189,14 +197,16 @@ See gif in action:
 
 ![multicursors](/images/multicursor.gif)
 
-## Custom keymaps for scrolling/window/tab/etc... management
+## Bindings
+
+**Custom keymaps for scrolling/window/tab/etc... management**
 
 -   See [vscode-scrolling.vim](/vim/vscode-scrolling.vim) for scrolling commands reference
 -   See [vscode-file-commands.vim](/vim/vscode-file-commands.vim) for file commands reference
 -   See [vscode-tab-commands.vim](/vim/vscode-tab-commands.vim) for tab commands reference
 -   See [vscode-window-commands.vim](/vim/vscode-window-commands.vim) for window commands reference
 
-## File/Tab management commands
+### File/Tab management commands
 
 `:e[dit]` or `ex`
 
@@ -289,7 +299,7 @@ See gif in action:
 
 Keys `ZZ` and `ZQ` are bound to `:wq` and `q!` respectively
 
-## Buffer/window management commands
+### Buffer/window management commands
 
 _Note_: split size distribution is controlled by `workbench.editor.splitSizing` setting. By default it's `distribute`, which is mapped to vim's `equalalways` and `eadirection = 'both'` (default)
 
@@ -406,11 +416,11 @@ To use VSCode command 'Increase/decrease current view size'
 
 -   Toggle maximized editor size. Pressing again will restore the size
 
-## Insert mode special keys
+### Insert mode special keys
 
-Enabled by `useCtrlKeysForInsertMode = true` (default true)
+Enabled by `useCtrlKeysForInsertMode = true` (default true).
 
-| Key                        | Desc                                                             | Status                            |
+| Key                        | Description                                                      | Status                            |
 | -------------------------- | ---------------------------------------------------------------- | --------------------------------- |
 | `CTRL-r [0-9a-z"%#*+:.-=]` | Paste from register                                              | Works                             |
 | `CTRL-a`                   | Paste previous inserted content                                  | Works                             |
@@ -420,14 +430,15 @@ Enabled by `useCtrlKeysForInsertMode = true` (default true)
 | `CTRL-t`                   | Indent lines right                                               | Bound to VSCode indent line       |
 | `CTRL-d`                   | Indent lines left                                                | Bound to VSCode outindent line    |
 | `CTRL-j`                   | Insert line                                                      | Bound to VSCode insert line after |
+| `CTRL-c`                   | Escape                                                           | Works                             |
 
-Other keys are not supported in insert mode
+Other keys are not supported in insert mode.
 
-## Normal mode control keys
+### Normal mode control keys
 
-Enabled by `useCtrlKeysForNormalMode = true` (default true)
+Enabled by `useCtrlKeysForNormalMode = true` (default true).
 
-Refer to vim manual to get help what they're doing
+Refer to vim manual for their use.
 
 -   CTRL-a
 -   CTRL-b
@@ -450,33 +461,38 @@ Refer to vim manual to get help what they're doing
 -   CTRL-h
 -   CTRL-/
 
-Other control keys are not being sent (Usually useless with vscode)
+### Cmdline control keys (always enabled)
 
-## Cmdline control keys (always enabled)
+| Key                 | Desription                                                |
+| ------------------- | --------------------------------------------------------- |
+| `CTRL-h`            | Delete one character left.                                |
+| `CTRL-w`            | Delete word left.                                         |
+| `CTRL-u`            | Clear line.                                               |
+| `CTRL-g` / `CTRL-t` | In incsearch mode moves to next/previous result.          |
+| `CTRL-l`            | Add next character under the cursor to incsearch.         |
+| `CTRL-n` / `CTRL-p` | Go down/up history.                                       |
+| `<Up>`/`<Down>`     | Select next/prev suggestion (cannot be used for history). |
+| `Tab`               | Select suggestion.                                        |
 
--   CTRL-h (delete one character left)
--   CTRL-w (delete word left)
--   CTRL-u (clear line)
--   CTRL-g / CTRL-t (in incsearch mode moves to next/previous result)
--   CTRL-l (add next character under the cursor to incsearch)
--   CTRL-n / CTRL-p (go down/up history)
--   `<Up>`/`<Down>` (Select next/prev suggestion) (no way to make up/down to navigate through history, vscode disallows remapping)
--   Tab - Select suggestion
+### Custom keybindings
 
-## Pass additional keys to neovim or disable existing ctrl keys mappings
+Control keys which are not in the above tables are not sent to neovim (as they are usually useless with vscode).
 
-### To pass additional ctrl key sequence, for example <C-Tab> add to your keybindings.json:
+To pass additional ctrl keys to neovim, for example `<C-Tab>`, add to your keybindings.json:
 
-```json
+```jsonc
 {
     "command": "vscode-neovim.send",
+    // the key sequence to activate the binding
     "key": "ctrl+tab",
+    // don't activate during insert mode
     "when": "editorTextFocus && neovim.mode != insert",
+    // the input to send to neovim
     "args": "<C-Tab>"
 }
 ```
 
-### To disable existing ctrl key sequence, for example Ctrl+A add to your keybindings.json
+To disable existing ctrl key sequence, for example `Ctrl+A` add to your keybindings.json:
 
 ```json
 {
@@ -485,39 +501,49 @@ Other control keys are not being sent (Usually useless with vscode)
 }
 ```
 
-## Vim-easymotion
+## Vim Plugins
 
-Speaking honestly, original [vim-easymotion](https://github.com/easymotion/vim-easymotion) works fine and as expected... except one thing: it really replaces your text with markers then restores back. It may work for VIM but for VS Code it leads to broken text and many errors reported while you're jumping. For this reason I created the special [vim-easymotion fork](https://github.com/asvetliakov/vim-easymotion) which doesn't touch your text and instead use vscode text decorations. Just add my fork to your `vim-plug` block or by using your favorite vim plugin installer and delete original vim-easymotion. Also overwin motions won't work (obviously) so don't use them. Happy jumping!
+Most vim plugins will work out of the box, but certain plugins may require some fixes to work properly.
+
+### Vim-easymotion
+
+While the original [vim-easymotion](https://github.com/easymotion/vim-easymotion) functions as expected, it works by replacing your text with markers then restoring back, which leads to broken text and many errors reported in VSCode.
+
+For this reason I created the special [vim-easymotion fork](https://github.com/asvetliakov/vim-easymotion) which doesn't touch your text and instead use vscode text decorations. Just add my fork to your `vim-plug` block or by using your favorite vim plugin installer and delete original vim-easymotion. Also overwin motions won't work (obviously) so don't use them.
+
+By default, text decorations will appear behind of the associated text as shown in the screenshot. To show the decorations on top of the text, set `vscode-neovim.textDecorationsAtTop` to true.
+
+Happy jumping!
 
 ![easymotion](/images/easy-motion-vscode.png)
 
-## Vim-commentary
+### Vim-commentary
 
-You can use [vim-commentary](https://github.com/tpope/vim-commentary) if you like it. But vscode already has such functionality so why don't use it? Add to your init.vim/init.nvim
+You can use [vim-commentary](https://github.com/tpope/vim-commentary) if you like it. But vscode already has such functionality so why don't use it? Add to your init.vim/init.nvim:
 
-```
+```vim
 xmap gc  <Plug>VSCodeCommentary
 nmap gc  <Plug>VSCodeCommentary
 omap gc  <Plug>VSCodeCommentary
 nmap gcc <Plug>VSCodeCommentaryLine
 ```
 
-Similar to vim-commentary, gcc is comment line (accept count), use gc with motion/in visual mode. `VSCodeCommentary` is just a simple function which calls `editor.action.commentLine`
+Similar to vim-commentary, gcc is comment line (accept count), use gc with motion/in visual mode. `VSCodeCommentary` is just a simple function which calls `editor.action.commentLine`.
 
-## VIM quick-scope
+### VIM quick-scope
 
-[quick-scope](https://github.com/unblevable/quick-scope) plugin uses default vim HL groups by default but they are normally ignored. To fix add
+[quick-scope](https://github.com/unblevable/quick-scope) plugin uses default vim HL groups by default but they are normally ignored. To fix, add
 
 ```vim
 highlight QuickScopePrimary guifg='#afff5f' gui=underline ctermfg=155 cterm=underline
 highlight QuickScopeSecondary guifg='#5fffff' gui=underline ctermfg=81 cterm=underline
 ```
 
-to your init.vim
+to your init.vim. The underline color can be changed by the `guisp` tag.
 
 ## Known Issues
 
-See [Issues section](https://github.com/asvetliakov/vscode-neovim/issues)
+See [Issues section](https://github.com/asvetliakov/vscode-neovim/issues).
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@
 <a href="https://gitter.im/vscode-neovim/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge"><img src="https://badges.gitter.im/vscode-neovim/community.svg"></a>
 </p>
 
-Neovim integration for Visual Studio Code.
+Real Neovim integration for Visual Studio Code.
 
-[Neovim](https://neovim.io/) is a fork of VIM to allow greater extensibility and integration. This extension uses a full embedded Neovim instance, no more half-complete VIM emulation! Control is given to VSCode for insert mode and window/buffer/file management, using the best of both editors.
+[Neovim](https://neovim.io/) is a fork of VIM to allow greater extensibility and integration. This extension uses a full embedded Neovim instance, no more half-complete VIM emulation! Control is given to VSCode for insert mode and window/buffer/file management, making the best use of both editors.
 
 ## Features
 
 -   Almost fully feature-complete VIM integration by utilizing neovim as a backend.
 -   Supports custom `init.vim` and many vim/neovim plugins.
 -   First-class VSCode insert mode. The plugin unbinds self from the `type` event in insert mode, so no more typing lag.
--   Full integration with VSCode features - autocompletion/go to definition/snippets/multiple cursors/etc...
+-   Full integration with VSCode features - autocompletion/go to definition/snippets/multiple cursors/etc.
 
 ## Requirements
 
@@ -41,32 +41,32 @@ If you want to use neovim from WSL, set `useWSL` configuration toggle and specif
 
 ### Important
 
--   Visual modes don't produce real vscode selections. Any vscode commands expecting selection won't work. To round the corners, invoking the VSCode command picker from visual mode through the default hotkeys (`f1`/`ctrl/cmd+shift+p`) converts vim selection to real vscode selection. This conversion is done automatically for some commands like commenting and formatting.
+-   Visual modes don't produce vscode selections. Any vscode commands expecting selection won't work. To round the corners, invoking the VSCode command picker from visual mode through the default hotkeys (<kbd>f1</kbd>/<kbd>ctrl/cmd+shift+p</kbd>) converts vim selection to real vscode selection. This conversion is done automatically for some commands like commenting and formatting.
 -   If you're using some custom mapping for calling vscode commands that depends on real vscode selection, you can use `VSCodeNotifyRange`/`VSCodeNotifyRangePos` (the first one linewise, the latter characterwise) functions which will convert visual mode selection to vscode selection before calling the command. See [this for example](https://github.com/asvetliakov/vscode-neovim/blob/e61832119988bb1e73b81df72956878819426ce2/vim/vscode-code-actions.vim#L42-L54) and [mapping](https://github.com/asvetliakov/vscode-neovim/blob/e61832119988bb1e73b81df72956878819426ce2/vim/vscode-code-actions.vim#L98).
--   The extension for now works best if `editor.scrollBeyondLastLine` is disabled.
+-   The extension works best if `editor.scrollBeyondLastLine` is disabled.
 -   When you type some commands they may be substituted for the another, like `:write` will be replaced by `:Write`. This is normal.
--   File/tab/window management (`:w`/`q`/etc...) commands are substituted and mapped to vscode actions. If you're using some custom commands/custom mappings to them, you might need to rebind them to call vscode actions instead. See reference links below for examples if you want to use custom keybindings/commands. **DO NOT** use vim `:w`, etc... in scripts/keybindings, they won't work.
--   On a Mac, the `h`, `j`, `k` and `l` movement keys may not repeat when held, to fix this open Terminal and execute the following command:
-    `defaults write com.microsoft.VSCode ApplePressAndHoldEnabled -bool false`
+-   File/tab/window management (`:w`/`:q`/etc) commands are substituted and mapped to vscode actions. If you're using some custom commands/custom mappings to them, you might need to rebind them to call vscode actions instead. See reference links below for examples if you want to use custom keybindings/commands. **DO NOT** use vim `:w`, etc in scripts/keybindings, they won't work.
+-   On a Mac, the <kbd>h</kbd>, <kbd>j</kbd>, <kbd>k</kbd> and <kbd>l</kbd> movement keys may not repeat when held, to fix this open Terminal and execute the following command:
+    `defaults write com.microsoft.VSCode ApplePressAndHoldEnabled -bool false`.
 
-### VSCode specific features and differences
+### VSCode specific differences
 
--   =, == are mapped to `editor.action.formatSelection`
+-   <kbd>=</kbd>, <kbd>==</kbd> are mapped to `editor.action.formatSelection`
 -   It's possible to call vscode commands from neovim. See `VSCodeCall/VSCodeNotify` vim functions in `vscode-neovim.vim` file. `VSCodeCall` is blocking request, while `VSCodeNotify` is not (see below).
--   Scrolling is done by VSCode side. `<C-d>/<C-u>/etc...` are slightly different.
--   File management commands such as `e` / `w` / `q` etc are mapped to corresponding vscode commands
+-   Scrolling is done by VSCode side. <kbd>C-d</kbd>/<kbd>C-u</kbd>/etc are slightly different.
+-   File management commands such as <kbd>e</kbd> / <kbd>w</kbd> / <kbd>q</kbd> / etc are mapped to corresponding vscode commands
     and behavior may be different (see below).
--   `gd`/`<C-]` are mapped to `editor.action.revealDefinition` (Shortcut `F12`), also `<C-]>` works
+-   <kbd>gd</kbd>/<kbd>C-]</kbd> are mapped to `editor.action.revealDefinition` (Shortcut `F12`), also <kbd>C-]</kbd> works
     in vim help files.
--   `gf` is mapped to `editor.action.revealDeclaration`
--   `gH` is mapped to `editor.action.referenceSearch.trigger`
--   `gD`/`gF` are mapped to `editor.action.peekDefinition` and `editor.action.peekDeclaration` respectively (opens in peek).
--   `<C-w>gd`/`<C-w>gf` are mapped to `editor.action.revealDefinitionAside` (original vim command -
+-   <kbd>gf</kbd> is mapped to `editor.action.revealDeclaration`
+-   <kbd>gH</kbd> is mapped to `editor.action.referenceSearch.trigger`
+-   <kbd>gD</kbd>/<kbd>gF</kbd> are mapped to `editor.action.peekDefinition` and `editor.action.peekDeclaration` respectively (opens in peek).
+-   <kbd>C-w</kbd> <kbd>gd</kbd>/<kbd>C-w</kbd> <kbd>gf</kbd> are mapped to `editor.action.revealDefinitionAside` (original vim command -
     open new tab and go to the file under cursor, but vscode/vim window/tabs metaphors are completely different, so it's useful to do slightly different thing here).
--   `gh` is mapped to `editor.action.showHover`
--   Dot-repeat (`.`). Moving cursor within a change range won't break the repeat sequence. I.e. in neovim, if you type `abc<cursor>` in insert mode then move cursor to `a<cursor>bc` and type `1` here the repeat sequence would be `1`. However in vscode it would be `a1bc`. Another difference that `.` repeat command when you delete some text only works from right-to-left. I.e. it will treat `<Del>` key as `<BS>` keys for dot repeat.
+-   <kbd>gh</kbd> is mapped to `editor.action.showHover`
+-   Dot-repeat (<kbd>.</kbd>). Moving cursor within a change range won't break the repeat sequence. In neovim, if you type `abc<cursor>` in insert mode, then move cursor to `a<cursor>bc` and type `1` here the repeat sequence would be `1`. However in vscode it would be `a1bc`. Another difference is that when you delete some text in insert mode, dot repeat only works from right-to-left, meaning it will treat <kbd>Del</kbd> key as <kbd>BS</kbd> keys when running dot repeat.
 
-### Performance/Latency problems
+### Performance problems
 
 If you have any performance problems (cursor jitter usually) make sure you're not using these kinds of extensions:
 
@@ -82,11 +82,11 @@ If you're not sure, disable all other extensions except mine, **reload vscode/wi
 
 Also there are reports that some vim settings/vim plugins increase latency and cause performance problems. Make sure you've disabled unneeded plugins. Many of them don't make sense with vscode and may cause problems. You don't need any code, highlighting, completion, lsp plugins as well any plugins that spawn windows/buffers (nerdtree and similar), fuzzy-finders plugins, etc. You might want to keep navigation/text-objects/text-editing/etc plugins - they should be fine.
 
-### Enabling jj or jk as escape keys from the insert mode
+### Custom escape keys
 
 Since VSCode is responsible for insert mode, custom insert-mode vim mappings don't work. To map composite escape keys, put into your keybindings.json:
 
-for `jj`
+for <kbd>jj</kbd>
 
 ```json
 {
@@ -97,7 +97,7 @@ for `jj`
 }
 ```
 
-to enable `jk` add also:
+to enable <kbd>jk</kbd> add also:
 
 ```json
 {
@@ -108,9 +108,9 @@ to enable `jk` add also:
 }
 ```
 
-### Determining if running in vscode in your init.vim
+### Conditional init.vim
 
-This should do the trick:
+To determine if neovim is running in vscode, add to your init.vim:
 
 ```vim
 if exists('g:vscode')
@@ -175,7 +175,7 @@ VSCode's jumplist is used instead of Neovim's. This is to make navigation caused
 
 ### Wildmenu completion
 
-Command menu has the wildmenu completion on type. The completion options appear after 1.5s (to not bother you when you write `:w` or `:noh`). `<Up>/<Down>` selects the option and `<Tab>` accepts it. See the gif:
+Command menu has the wildmenu completion on type. The completion options appear after 1.5s (to not bother you when you write `:w` or `:noh`). <kbd>Up</kbd>/<kbd>Down</kbd> selects the option and <kbd>Tab</kbd> accepts it. See the gif:
 
 ![wildmenu](/images/wildmenu.gif)
 
@@ -187,11 +187,11 @@ Multiple cursors work in:
 2. (Optional) Visual line mode
 3. (Optional) Visual block mode
 
-To spawn multiple cursors from visual line/block modes type `ma`/`mA` or `mi`/`mI` (by default). The effect differs:
+To spawn multiple cursors from visual line/block modes type <kbd>ma</kbd>/<kbd>mA</kbd> or <kbd>mi</kbd>/<kbd>mI</kbd> (by default). The effect differs:
 
--   For visual line mode `mi` will start insert mode on each selected line on the first non whitespace character and `ma` will on the end of line
--   For visual block mode `mi` will start insert on each selected line before the cursor block and `ma` after
--   `mA`/`mI` versions account empty lines too (only for visual line mode, for visual block mode they're same as ma/mi)
+-   For visual line mode <kbd>mi</kbd> will start insert mode on each selected line on the first non whitespace character and <kbd>ma</kbd> will on the end of line
+-   For visual block mode <kbd>mi</kbd> will start insert on each selected line before the cursor block and <kbd>ma</kbd> after
+-   <kbd>mA</kbd>/<kbd>mI</kbd> versions account empty lines too (only for visual line mode, for visual block mode they're same as <kbd>ma</kbd>/<kbd>mi</kbd>)
 
 See gif in action:
 
@@ -199,14 +199,14 @@ See gif in action:
 
 ## Bindings
 
-**Custom keymaps for scrolling/window/tab/etc... management**
+**Custom keymaps for scrolling/window/tab/etc management**
 
 -   See [vscode-scrolling.vim](/vim/vscode-scrolling.vim) for scrolling commands reference
 -   See [vscode-file-commands.vim](/vim/vscode-file-commands.vim) for file commands reference
 -   See [vscode-tab-commands.vim](/vim/vscode-tab-commands.vim) for tab commands reference
 -   See [vscode-window-commands.vim](/vim/vscode-window-commands.vim) for window commands reference
 
-### File/Tab management commands
+### File/Tab management
 
 | Command                                | Description                                                                                                                                                                                                                                                                                                                                                   |
 | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -232,34 +232,34 @@ See gif in action:
 | `tabl[ast]`                            | Switches to the last tab in the active edtior group.                                                                                                                                                                                                                                                                                                          |
 | `tabm[ove]`                            | Not supported yet.                                                                                                                                                                                                                                                                                                                                            |
 
-Keys `ZZ` and `ZQ` are bound to `:wq` and `q!` respectively
+Keys <kbd>ZZ</kbd> and <kbd>ZQ</kbd> are bound to `:wq` and `q!` respectively
 
-### Buffer/window management commands
+### Buffer/window management
 
 _Note_: split size distribution is controlled by `workbench.editor.splitSizing` setting. By default, it's `distribute`, which is mapped to vim's `equalalways` and `eadirection = 'both'` (default).
 
-| Command                        | Key                        | Description                                                                                                                                                                                                                                                                              |
-| ------------------------------ | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `sp[lit]`                      | `<C-w> s`                  | Split editor horizontally. <br/> When argument given opens the specified file in the argument, e.g `:sp $MYVIMRC`. File must exist.                                                                                                                                                      |
-| `vs[plit]`                     | `<C-w> v`                  | Split editor vertically. <br/> When argument given opens the specified file in the argument. File must exist.                                                                                                                                                                            |
-| `new`                          | `<C-w> n`                  | Like `sp[lit]` but creates new untitled file if no argument given.                                                                                                                                                                                                                       |
-| `vne[w]`                       |                            | Like `vs[plit]` but creates new untitled file if no argument given.                                                                                                                                                                                                                      |
-|                                | `<C-w> ^`                  | Not supported yet.                                                                                                                                                                                                                                                                       |
-| `vert[ical]`/`lefta[bove]`/etc |                            | Not supported yet.                                                                                                                                                                                                                                                                       |
-| `on[ly]`                       | `<C-w> o`                  | Without bang (`!`): merges all editor groups into the one. **Doesn't** close editors. <br/> With bang: closes all editors from all groups except current one.                                                                                                                            |
-|                                | `<C-w> j/k/h/l`            | Focus group below/above/left/right.                                                                                                                                                                                                                                                      |
-|                                | `<C-w> <C-j/i/h/l>`        | Move editor to group below/above/left/right. Vim doesn't have analogue mappings. **Note**: `<C-w> <C-i>` moves editor up. Logically it should be `<C-w> <C-k>` but vscode has many commands mapped to `<C-k> [key]` and doesn't allow to use `<C-w> <C-k>` without unbinding them first. |
-|                                | `<C-w> r/R/x`              | Not supported, use `<C-w> <C-j>` and similar to move editors.                                                                                                                                                                                                                            |
-|                                | `<C-w> w` or `<C-w> <C-w>` | Focus next group. The behavior may differ than in vim.                                                                                                                                                                                                                                   |
-|                                | `<C-w> W` or `<C-w> p`     | Focus previous group. The behavior may differ than in vim. `<C-w> p` is completely different than in vim.                                                                                                                                                                                |
-|                                | `<C-w> b`                  | Focus last editor group (most bottom-right).                                                                                                                                                                                                                                             |
-|                                | `<C-w> H/K/J/L`            | Not supported yet.                                                                                                                                                                                                                                                                       |
-|                                | `<C-w> =`                  | Align all editors to have the same width.                                                                                                                                                                                                                                                |
-|                                | `[count]<C-w> +`           | Increase editor height by (optional) count.                                                                                                                                                                                                                                              |
-|                                | `[count]<C-w> -`           | Decrease editor height by (optional) count.                                                                                                                                                                                                                                              |
-|                                | `[count]<C-w> >`           | Increase editor width by (optional) count.                                                                                                                                                                                                                                               |
-|                                | `[count]<C-w> <`           | Decrease editor width by (optional) count.                                                                                                                                                                                                                                               |
-|                                | `<C-w> _`                  | Toggle maximized editor size. Pressing again will restore the size.                                                                                                                                                                                                                      |
+| Command                        | Key                                                          | Description                                                                                                                                                                                                                                                                                                                                                |
+| ------------------------------ | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sp[lit]`                      | <kbd>C-w</kbd> <kbd>s</kbd>                                  | Split editor horizontally. <br/> When argument given opens the specified file in the argument, e.g `:sp $MYVIMRC`. File must exist.                                                                                                                                                                                                                        |
+| `vs[plit]`                     | <kbd>C-w</kbd> <kbd>v</kbd>                                  | Split editor vertically. <br/> When argument given opens the specified file in the argument. File must exist.                                                                                                                                                                                                                                              |
+| `new`                          | <kbd>C-w</kbd> <kbd>n</kbd>                                  | Like `sp[lit]` but creates new untitled file if no argument given.                                                                                                                                                                                                                                                                                         |
+| `vne[w]`                       |                                                              | Like `vs[plit]` but creates new untitled file if no argument given.                                                                                                                                                                                                                                                                                        |
+|                                | <kbd>C-w</kbd> <kbd>^</kbd>                                  | Not supported yet.                                                                                                                                                                                                                                                                                                                                         |
+| `vert[ical]`/`lefta[bove]`/etc |                                                              | Not supported yet.                                                                                                                                                                                                                                                                                                                                         |
+| `on[ly]`                       | <kbd>C-w</kbd> <kbd>o</kbd>                                  | Without bang (`!`): merges all editor groups into the one. **Doesn't** close editors. <br/> With bang: closes all editors from all groups except current one.                                                                                                                                                                                              |
+|                                | <kbd>C-w</kbd> <kbd>j/k/h/l</kbd>                            | Focus group below/above/left/right.                                                                                                                                                                                                                                                                                                                        |
+|                                | <kbd>C-w</kbd> <kbd>C-j/i/h/l</kbd>                          | Move editor to group below/above/left/right. Vim doesn't have analogue mappings. **Note**: <kbd>C-w</kbd> <kbd>C-i</kbd> moves editor up. Logically it should be <kbd>C-w</kbd> <kbd>C-k</kbd> but vscode has many commands mapped to <kbd>C-k</kbd> <kbd>[key]</kbd> and doesn't allow to use <kbd>C-w</kbd> <kbd>C-k</kbd> without unbinding them first. |
+|                                | <kbd>C-w</kbd> <kbd>r/R/x</kbd>                              | Not supported, use <kbd>C-w</kbd> <kbd>C-j</kbd> and similar to move editors.                                                                                                                                                                                                                                                                              |
+|                                | <kbd>C-w</kbd> <kbd>w</kbd> or <kbd>C-w</kbd> <kbd>C-w</kbd> | Focus next group. The behavior may differ than in vim.                                                                                                                                                                                                                                                                                                     |
+|                                | <kbd>C-w</kbd> <kbd>W</kbd> or <kbd>C-w</kbd> <kbd>p</kbd>   | Focus previous group. The behavior may differ than in vim. <kbd>C-w</kbd> <kbd>p</kbd> is completely different than in vim.                                                                                                                                                                                                                                |
+|                                | <kbd>C-w</kbd> <kbd>b</kbd>                                  | Focus last editor group (most bottom-right).                                                                                                                                                                                                                                                                                                               |
+|                                | <kbd>C-w</kbd> <kbd>H/K/J/L</kbd>                            | Not supported yet.                                                                                                                                                                                                                                                                                                                                         |
+|                                | <kbd>C-w</kbd> <kbd>=</kbd>                                  | Align all editors to have the same width.                                                                                                                                                                                                                                                                                                                  |
+|                                | <kbd>[count] C-w</kbd> <kbd>+</kbd>                          | Increase editor height by (optional) count.                                                                                                                                                                                                                                                                                                                |
+|                                | <kbd>[count] C-w</kbd> <kbd>-</kbd>                          | Decrease editor height by (optional) count.                                                                                                                                                                                                                                                                                                                |
+|                                | <kbd>[count] C-w</kbd> <kbd>></kbd>                          | Increase editor width by (optional) count.                                                                                                                                                                                                                                                                                                                 |
+|                                | <kbd>[count] C-w</kbd> <kbd>\<</kbd>                         | Decrease editor width by (optional) count.                                                                                                                                                                                                                                                                                                                 |
+|                                | <kbd>C-w</kbd> <kbd>\_</kbd>                                 | Toggle maximized editor size. Pressing again will restore the size.                                                                                                                                                                                                                                                                                        |
 
 To use VSCode command 'Increase/decrease current view size' instead of separate bindings for width and height:
 
@@ -292,17 +292,17 @@ To use VSCode command 'Increase/decrease current view size' instead of separate 
 
 Enabled by `useCtrlKeysForInsertMode = true` (default true).
 
-| Key                        | Description                                                      | Status                            |
-| -------------------------- | ---------------------------------------------------------------- | --------------------------------- |
-| `CTRL-r [0-9a-z"%#*+:.-=]` | Paste from register                                              | Works                             |
-| `CTRL-a`                   | Paste previous inserted content                                  | Works                             |
-| `CTRL-u`                   | Delete all text till begining of line, if empty - delete newline | Bound to VSCode key               |
-| `CTRL-w`                   | Delete word left                                                 | Bound to VSCode key               |
-| `CTRL-h`                   | Delete character left                                            | Bound to VSCode key               |
-| `CTRL-t`                   | Indent lines right                                               | Bound to VSCode indent line       |
-| `CTRL-d`                   | Indent lines left                                                | Bound to VSCode outindent line    |
-| `CTRL-j`                   | Insert line                                                      | Bound to VSCode insert line after |
-| `CTRL-c`                   | Escape                                                           | Works                             |
+| Key                              | Description                                                       | Status                            |
+| -------------------------------- | ----------------------------------------------------------------- | --------------------------------- |
+| <kbd>C-r [0-9a-z"%#*+:.-=]</kbd> | Paste from register                                               | Works                             |
+| <kbd>C-a</kbd>                   | Paste previous inserted content                                   | Works                             |
+| <kbd>C-u</kbd>                   | Delete all text till beginning of line, if empty - delete newline | Bound to VSCode key               |
+| <kbd>C-w</kbd>                   | Delete word left                                                  | Bound to VSCode key               |
+| <kbd>C-h</kbd>                   | Delete character left                                             | Bound to VSCode key               |
+| <kbd>C-t</kbd>                   | Indent lines right                                                | Bound to VSCode indent line       |
+| <kbd>C-d</kbd>                   | Indent lines left                                                 | Bound to VSCode outindent line    |
+| <kbd>C-j</kbd>                   | Insert line                                                       | Bound to VSCode insert line after |
+| <kbd>C-c</kbd>                   | Escape                                                            | Works                             |
 
 Other keys are not supported in insert mode.
 
@@ -312,45 +312,45 @@ Enabled by `useCtrlKeysForNormalMode = true` (default true).
 
 Refer to vim manual for their use.
 
--   `CTRL-a`
--   `CTRL-b`
--   `CTRL-c`
--   `CTRL-d`
--   `CTRL-e`
--   `CTRL-f`
--   `CTRL-i`
--   `CTRL-o` (see https://github.com/asvetliakov/vscode-neovim/issues/181#issuecomment-585264621)
--   `CTRL-r`
--   `CTRL-u`
--   `CTRL-v`
--   `CTRL-w`
--   `CTRL-x`
--   `CTRL-y`
--   `CTRL-]`
--   `CTRL-j`
--   `CTRL-k`
--   `CTRL-l`
--   `CTRL-h`
--   `CTRL-/`
+-   <kbd>C-a</kbd>
+-   <kbd>C-b</kbd>
+-   <kbd>C-c</kbd>
+-   <kbd>C-d</kbd>
+-   <kbd>C-e</kbd>
+-   <kbd>C-f</kbd>
+-   <kbd>C-i</kbd>
+-   <kbd>C-o</kbd> (see https://github.com/asvetliakov/vscode-neovim/issues/181#issuecomment-585264621)
+-   <kbd>C-r</kbd>
+-   <kbd>C-u</kbd>
+-   <kbd>C-v</kbd>
+-   <kbd>C-w</kbd>
+-   <kbd>C-x</kbd>
+-   <kbd>C-y</kbd>
+-   <kbd>C-]</kbd>
+-   <kbd>C-j</kbd>
+-   <kbd>C-k</kbd>
+-   <kbd>C-l</kbd>
+-   <kbd>C-h</kbd>
+-   <kbd>C-/</kbd>
 
 ### Cmdline control keys (always enabled)
 
-| Key                 | Desc                                                     |
-|---------------------|----------------------------------------------------------|
-| `CTRL-h`            | Delete one character left                                |
-| `CTRL-w`            | Delete word left                                         |
-| `CTRL-u`            | Clear line                                               |
-| `CTRL-g` / `CTRL-t` | In incsearch mode moves to next/previous result          |
-| `CTRL-l`            | Add next character under the cursor to incsearch         |
-| `CTRL-n` / `CTRL-p` | Go down/up history                                       |
-| `<Up>`/`<Down>`     | Select next/prev suggestion (cannot be used for history) |
-| `Tab`               | Select suggestion                                        |
+| Key                             | Desription                                                |
+| ------------------------------- | --------------------------------------------------------- |
+| <kbd>C-h</kbd>                  | Delete one character left.                                |
+| <kbd>C-w</kbd>                  | Delete word left.                                         |
+| <kbd>C-u</kbd>                  | Clear line.                                               |
+| <kbd>C-g</kbd> / <kbd>C-t</kbd> | In incsearch mode moves to next/previous result.          |
+| <kbd>C-l</kbd>                  | Add next character under the cursor to incsearch.         |
+| <kbd>C-n</kbd> / <kbd>C-p</kbd> | Go down/up history.                                       |
+| <kbd>Up</kbd>/<kbd>Down</kbd>   | Select next/prev suggestion (cannot be used for history). |
+| <kbd>Tab</kbd>                  | Select suggestion.                                        |
 
 ### Custom keybindings
 
 Control keys which are not in the above tables are not sent to neovim (as they are usually useless with vscode).
 
-To pass additional ctrl keys to neovim, for example `<C-Tab>`, add to your keybindings.json:
+To pass additional ctrl keys to neovim, for example <kbd>C-Tab</kbd>, add to your keybindings.json:
 
 ```jsonc
 {
@@ -364,7 +364,7 @@ To pass additional ctrl keys to neovim, for example `<C-Tab>`, add to your keybi
 }
 ```
 
-To disable existing ctrl key sequence, for example `Ctrl+A` add to your keybindings.json:
+To disable existing ctrl key sequence, for example <kbd>C-A</kbd> add to your keybindings.json:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -120,6 +120,19 @@ else
 endif
 ```
 
+To conditionally enable plugins, `vim-plug` has a [few solutions](https://github.com/junegunn/vim-plug/wiki/tips#conditional-activation).
+
+For example, using the `Cond` helper, you can do the following to conditionally activate plugins while having them all still installed
+([source](https://github.com/asvetliakov/vscode-neovim/issues/415#issuecomment-715533865)):
+
+```vim
+" inside plug#begin:
+" use normal easymotion when in vim mode
+Plug 'easymotion/vim-easymotion', Cond(!exists('g:vscode'))
+" use vscode easymotion when in vscode mode
+Plug 'asvetliakov/vim-easymotion', Cond(exists('g:vscode'), { 'as': 'vsc-easymotion' })
+```
+
 ### Invoking vscode actions from neovim
 
 There are [few helper functions](https://github.com/asvetliakov/vscode-neovim/blob/ecd361ff1968e597e2500e8ce1108830e918cfb8/vim/vscode-neovim.vim#L17-L39) that could be used to invoke any vscode commands:

--- a/README.md
+++ b/README.md
@@ -32,14 +32,16 @@ editor commands, making the best use of both editors.
     -   [Multiple cursors](#multiple-cursors)
     -   [Keyboard Quickfix](#keyboard-quickfix)
 -   [⌨️ Bindings](#️-bindings)
-    -   [File/Tab management](#filetab-management)
+    -   [File management](#file-management)
+    -   [Tab management](#tab-management)
     -   [Buffer/window management](#bufferwindow-management)
     -   [Insert mode special keys](#insert-mode-special-keys)
     -   [Normal mode control keys](#normal-mode-control-keys)
-    -   [Cmdline control keys (always enabled)](#cmdline-control-keys-always-enabled)
-    -   [VSCode navigation bindings](#vscode-navigation-bindings)
+    -   [Cmdline special keys](#cmdline-special-keys)
+    -   [VSCode specific bindings](#vscode-specific-bindings)
         -   [Explorer/list navigation](#explorerlist-navigation)
         -   [Explorer file manipulation](#explorer-file-manipulation)
+        -   [Editor commands](#editor-commands)
     -   [Custom keybindings](#custom-keybindings)
 -   [🤝 Vim Plugins](#-vim-plugins)
     -   [vim-easymotion](#vim-easymotion)
@@ -66,56 +68,46 @@ editor commands, making the best use of both editors.
 > ❗ **Neovim 0.5 nightly** or greater is **required**. Any version lower than that won't work. Many linux distributions
 > have an **old** version of neovim in their package repo - always check what version are you installing.
 
-> ⚠️ If you get "Unable to init vscode-neovim: command 'type' already exists" message, uninstall other VSCode extensions
-> that register `type` command (i.e. [VSCodeVim](https://marketplace.visualstudio.com/items?itemName=vscodevim.vim) or
-> [Overtype](https://marketplace.visualstudio.com/items?itemName=adammaras.overtype)).
-
 > 🐛 See the [issues section](https://github.com/asvetliakov/vscode-neovim/issues) for known issues.
 
 ## 💡 Tips and Features
 
 ### Important
 
+-   If you get "Unable to init vscode-neovim: command 'type' already exists" message, uninstall other VSCode extensions
+    that register the `type` command (like
+    [VSCodeVim](https://marketplace.visualstudio.com/items?itemName=vscodevim.vim) or
+    [Overtype](https://marketplace.visualstudio.com/items?itemName=adammaras.overtype)).
 -   If you already have a big `init.vim` it is recommended to wrap existing settings & plugins with
     [`if !exists('g:vscode')`](#determining-if-running-in-vscode-in-your-initvim) to prevent potential conflicts. If you
     have any problems, try with empty `init.vim` first.
+-   On a Mac, the <kbd>h</kbd>, <kbd>j</kbd>, <kbd>k</kbd> and <kbd>l</kbd> movement keys may not repeat when held, to
+    fix this open Terminal and execute the following command:
+    `defaults write com.microsoft.VSCode ApplePressAndHoldEnabled -bool false`.
+-   The extension works best if `editor.scrollBeyondLastLine` is disabled.
+
+### VSCode specific differences
+
+-   File and editor management commands such as `:e`/`:w`/`:q`/`:vsplit`/`:tabnext`/etc are mapped to corresponding
+    vscode commands and behavior may be different (see below). If you're using some custom commands/custom mappings to
+    them, you might need to rebind them to call vscode actions instead. See reference links below for examples if you
+    want to use custom keybindings/commands. **do not** use vim `:w`, etc in scripts/keybindings, they won't work.
+-   Scrolling is done by VSCode. <kbd>C-d</kbd>/<kbd>C-u</kbd>/etc are slightly different.
+-   Editor customization (relative line number, scrolloff, etc) is handled by VSCode.
+-   It's possible to call vscode commands from neovim. See `VSCodeCall/VSCodeNotify` vim functions in
+    `vscode-neovim.vim` file. `VSCodeCall` is blocking request, while `VSCodeNotify` is not (see below).
 -   Visual modes don't produce vscode selections, so any vscode commands expecting selection won't work. To round the
     corners, invoking the VSCode command picker from visual mode through the default hotkeys
     (<kbd>f1</kbd>/<kbd>ctrl/cmd+shift+p</kbd>) converts vim selection to real vscode selection. This conversion is done
     automatically for some commands like commenting and formatting.
 -   If you're using some custom mapping for calling vscode commands that depends on real vscode selection, you can use
-    `VSCodeNotifyRange`/`VSCodeNotifyRangePos` (the first one linewise, the latter characterwise) functions which will
-    convert visual mode selection to vscode selection before calling the command. See
+    `VSCodeNotifyRange`/`VSCodeNotifyRangePos` (the first one linewise, the latter characterwise) which will convert vim
+    visual mode selection to vscode selection before calling the command. See
     [this for example](https://github.com/asvetliakov/vscode-neovim/blob/e61832119988bb1e73b81df72956878819426ce2/vim/vscode-code-actions.vim#L42-L54)
     and
     [mapping](https://github.com/asvetliakov/vscode-neovim/blob/e61832119988bb1e73b81df72956878819426ce2/vim/vscode-code-actions.vim#L98).
--   The extension works best if `editor.scrollBeyondLastLine` is disabled.
 -   When you type some commands they may be substituted for the another, like `:write` will be replaced by `:Write`.
     This is normal.
--   File/tab/window management (`:w`/`:q`/etc) commands are substituted and mapped to vscode actions. If you're using
-    some custom commands/custom mappings to them, you might need to rebind them to call vscode actions instead. See
-    reference links below for examples if you want to use custom keybindings/commands. **do not** use vim `:w`, etc in
-    scripts/keybindings, they won't work.
--   On a Mac, the <kbd>h</kbd>, <kbd>j</kbd>, <kbd>k</kbd> and <kbd>l</kbd> movement keys may not repeat when held, to
-    fix this open Terminal and execute the following command:
-    `defaults write com.microsoft.VSCode ApplePressAndHoldEnabled -bool false`.
-
-### VSCode specific differences
-
--   <kbd>=</kbd>, <kbd>==</kbd> are mapped to `editor.action.formatSelection`
--   It's possible to call vscode commands from neovim. See `VSCodeCall/VSCodeNotify` vim functions in
-    `vscode-neovim.vim` file. `VSCodeCall` is blocking request, while `VSCodeNotify` is not (see below).
--   Scrolling is done by VSCode side. <kbd>C-d</kbd>/<kbd>C-u</kbd>/etc are slightly different.
--   File management commands such as <kbd>e</kbd> / <kbd>w</kbd> / <kbd>q</kbd> / etc are mapped to corresponding vscode
-    commands and behavior may be different (see below).
--   <kbd>gd</kbd>/<kbd>C-]</kbd> are mapped to `editor.action.revealDefinition` (Shortcut `F12`), also <kbd>C-]</kbd>
-    works in vim help files.
--   <kbd>gf</kbd> is mapped to `editor.action.revealDeclaration`
--   <kbd>gH</kbd> is mapped to `editor.action.referenceSearch.trigger`
--   <kbd>gD</kbd>/<kbd>gF</kbd> are mapped to `editor.action.peekDefinition` and `editor.action.peekDeclaration`
-    respectively.
--   <kbd>C-w</kbd> <kbd>gd</kbd>/<kbd>C-w</kbd> <kbd>gf</kbd> are mapped to `editor.action.revealDefinitionAside`.
--   <kbd>gh</kbd> is mapped to `editor.action.showHover`
 -   Dot-repeat (<kbd>.</kbd>) is slightly different - moving the cursor within a change range won't break the repeat
     sequence. In neovim, if you type `abc<cursor>` in insert mode, then move cursor to `a<cursor>bc` and type `1` here
     the repeat sequence would be `1`. However in vscode it would be `a1bc`. Another difference is that when you delete
@@ -131,10 +123,11 @@ If you have any performance problems (cursor jitter usually) make sure you're no
     -   Indent guide extensions (VSCode has built-in indent guides)
     -   Brackets highlighter extensions (VSCode has built-in feature)
 -   VSCode extensions that delay the extension host like "Bracket Pair Colorizer"
--   VIM plugins that increase latency and cause performance problems. - Make sure to disable unneeded plugins, as many
-    of them don't make sense with vscode and may cause problems. - You don't need any code, highlighting, completion,
-    lsp plugins as well any plugins that spawn windows/buffers (nerdtree and similar), fuzzy-finders plugins, etc. - You
-    might want to keep navigation/text-objects/text-editing/etc plugins - they should be fine.
+-   VIM plugins that increase latency and cause performance problems.
+    -   Make sure to disable unneeded plugins, as many of them don't make sense with vscode and may cause problems.
+    -   You don't need any code, highlighting, completion, lsp plugins as well any plugins that spawn windows/buffers
+        (nerdtree and similar), fuzzy-finders plugins, etc.
+    -   Many navigation/textobject/editing plugins should be fine.
 
 If you're not sure, disable all other extensions, **reload vscode/window** and see if the problem persists before
 reporting.
@@ -317,61 +310,64 @@ nnoremap z= <Cmd>call VSCodeNotify('keyboard-quickfix.openQuickFix')<CR>
 -   See [vscode-tab-commands.vim](/vim/vscode-tab-commands.vim) for tab commands reference
 -   See [vscode-window-commands.vim](/vim/vscode-window-commands.vim) for window commands reference
 
-### File/Tab management
+"With bang" refers to adding a `!` at the end of a command.
 
-| Command                                                               | Description                                                                                                                                                                                                                                                                                                                                                   |
-| --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `:e[dit]` or `ex`                                                     | Without argument and without bang (`!`): opens quickopen window. <br/> Without argument and with bang: opens open file dialog. <br/> With filename, e.g. `:e $MYVIMRC`: opens a file in new tab. The file must exist. <br/> With filename and with bang e.g. `:e! $MYVIMRC`: closes current file (discard any changes) and opens a file. The file must exist. |
-| `ene[w]`                                                              | Without bang: creates new untitled document in vscode. <br/> With bang: closes current file (discard any changes) and creates new untitled document.                                                                                                                                                                                                          |
-| `fin[d]`                                                              | Opens vscode's quick open window. Arguments and count are not supported.                                                                                                                                                                                                                                                                                      |
-| `w[rite]`                                                             | Without bang (`!`) saves current file. With bang opens 'save as' dialog.                                                                                                                                                                                                                                                                                      |
-| `sav[eas]`                                                            | Opens 'save as' dialog.                                                                                                                                                                                                                                                                                                                                       |
-| `wa[ll]`                                                              | Saves all files.                                                                                                                                                                                                                                                                                                                                              |
-| `q[uit]` or <kbd>C-w</kbd> <kbd>q</kbd> / <kbd>C-w</kbd> <kbd>c</kbd> | Closes the active editor.                                                                                                                                                                                                                                                                                                                                     |
-| `wq`                                                                  | Saves and closes the active editor.                                                                                                                                                                                                                                                                                                                           |
-| `qa[ll]`                                                              | Closes all editors, but doesn't quit vscode. Acts like `qall!`, so beware for nonsaved changes.                                                                                                                                                                                                                                                               |
-| `wqa[ll]`/`xa[ll]`                                                    | Saves all editors & close.                                                                                                                                                                                                                                                                                                                                    |
-| `tabe[dit]`                                                           | Similar to `e[dit]`. Without argument opens quickopen, with argument opens the file in new tab.                                                                                                                                                                                                                                                               |
-| `tabnew`                                                              | Opens new untitled file.                                                                                                                                                                                                                                                                                                                                      |
-| `tabf[ind]`                                                           | Opens quickopen window.                                                                                                                                                                                                                                                                                                                                       |
-| `tab`/`tabs`                                                          | Not supported. Doesn't make sense with vscode.                                                                                                                                                                                                                                                                                                                |
-| `tabc[lose]`                                                          | Closes active editor (tab).                                                                                                                                                                                                                                                                                                                                   |
-| `tabo[nly]`                                                           | Closes other tabs in vscode **group** (pane). This differs from vim where a `tab` is a like a new window, but doesn't make sense in vscode.                                                                                                                                                                                                                   |
-| `tabn[ext]` or <kbd>gt</kbd>                                          | Switches to next (or `count` tabs if argument is given) in the active vscode **group** (pane).                                                                                                                                                                                                                                                                |
-| `tabp[revious]` or <kbd>gT</kbd>                                      | Switches to previous (or `count` tabs if argument is given) in the active vscode **group** (pane).                                                                                                                                                                                                                                                            |
-| `tabfir[st]`                                                          | Switches to the first tab in the active editor group.                                                                                                                                                                                                                                                                                                         |
-| `tabl[ast]`                                                           | Switches to the last tab in the active edtior group.                                                                                                                                                                                                                                                                                                          |
-| `tabm[ove]`                                                           | Not supported yet.                                                                                                                                                                                                                                                                                                                                            |
+### File management
 
-Keys <kbd>ZZ</kbd> and <kbd>ZQ</kbd> are bound to `:wq` and `q!` respectively
+| Command                                                                              | Description                                                                                                                                                                                                                                                                                                                                        |
+| ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `e[dit]` / `ex`                                                                      | Without argument and without bang: open quickopen window. <br/> Without argument and with bang: open open file dialog. <br/> With filename, e.g. `:e $MYVIMRC`: open a file in new tab. The file must exist. <br/> With filename and with bang e.g. `:e! $MYVIMRC`: close current file (discard any changes) and open a file. The file must exist. |
+| `ene[w]`                                                                             | Without bang: create new untitled document in vscode. <br/> With bang: close current file (discard any changes) and create new document.                                                                                                                                                                                                           |
+| `fin[d]`                                                                             | Open vscode's quick open window. Arguments and count are not supported.                                                                                                                                                                                                                                                                            |
+| `w[rite]`                                                                            | Without bang: save current file. With bang: open 'save as' dialog.                                                                                                                                                                                                                                                                                 |
+| `sav[eas]`                                                                           | Open 'save as' dialog.                                                                                                                                                                                                                                                                                                                             |
+| `wa[ll]`                                                                             | Save all files.                                                                                                                                                                                                                                                                                                                                    |
+| `q[uit]` / <kbd>C-w</kbd> <kbd>q</kbd> / <kbd>C-w</kbd> <kbd>c</kbd> / <kbd>ZQ</kbd> | Close the active editor. With bang: revert changes and close the active editor.                                                                                                                                                                                                                                                                    |
+| `wq` / <kbd>ZZ</kbd>                                                                 | Save and close the active editor.                                                                                                                                                                                                                                                                                                                  |
+| `qa[ll]`                                                                             | Close all editors, but don't quit vscode. Acts like `qall!`, so beware for nonsaved changes.                                                                                                                                                                                                                                                       |
+| `wqa[ll]` / `xa[ll]`                                                                 | Save all editors & close.                                                                                                                                                                                                                                                                                                                          |
+
+### Tab management
+
+| Command                         | Description                                                                                                                                |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `tabe[dit]`                     | Similar to `e[dit]`. <br/> Without argument: open quickopen. <br/> With argument: open the file in new tab.                                |
+| `tabnew`                        | Open new untitled file.                                                                                                                    |
+| `tabf[ind]`                     | Open quickopen window.                                                                                                                     |
+| `tab`/`tabs`                    | Not supported. Doesn't make sense with vscode.                                                                                             |
+| `tabc[lose]`                    | Close active editor (tab).                                                                                                                 |
+| `tabo[nly]`                     | Close other tabs in vscode **group** (pane). This differs from vim where a `tab` is a like a new window, but doesn't make sense in vscode. |
+| `tabn[ext]` / <kbd>gt</kbd>     | Switch to next (or `count` tabs if argument is given) in the active vscode **group** (pane).                                               |
+| `tabp[revious]` / <kbd>gT</kbd> | Switch to previous (or `count` tabs if argument is given) in the active vscode **group** (pane).                                           |
+| `tabfir[st]`                    | Switch to the first tab in the active editor group.                                                                                        |
+| `tabl[ast]`                     | Switch to the last tab in the active editor group.                                                                                         |
+| `tabm[ove]`                     | Not supported yet.                                                                                                                         |
 
 ### Buffer/window management
 
 _Note_: split size distribution is controlled by `workbench.editor.splitSizing` setting. By default, it's `distribute`,
 which is mapped to vim's `equalalways` and `eadirection = 'both'` (default).
 
-| Command                        | Key                                                          | Description                                                                                                                                                                                                                                                                                                                                                |
-| ------------------------------ | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `sp[lit]`                      | <kbd>C-w</kbd> <kbd>s</kbd>                                  | Split editor horizontally. <br/> When argument given opens the specified file in the argument, e.g `:sp $MYVIMRC`. File must exist.                                                                                                                                                                                                                        |
-| `vs[plit]`                     | <kbd>C-w</kbd> <kbd>v</kbd>                                  | Split editor vertically. <br/> When argument given opens the specified file in the argument. File must exist.                                                                                                                                                                                                                                              |
-| `new`                          | <kbd>C-w</kbd> <kbd>n</kbd>                                  | Like `sp[lit]` but creates new untitled file if no argument given.                                                                                                                                                                                                                                                                                         |
-| `vne[w]`                       |                                                              | Like `vs[plit]` but creates new untitled file if no argument given.                                                                                                                                                                                                                                                                                        |
-|                                | <kbd>C-w</kbd> <kbd>^</kbd>                                  | Not supported yet.                                                                                                                                                                                                                                                                                                                                         |
-| `vert[ical]`/`lefta[bove]`/etc |                                                              | Not supported yet.                                                                                                                                                                                                                                                                                                                                         |
-| `on[ly]`                       | <kbd>C-w</kbd> <kbd>o</kbd>                                  | Without bang (`!`): merges all editor groups into the one. **Doesn't** close editors. <br/> With bang: closes all editors from all groups except current one.                                                                                                                                                                                              |
-|                                | <kbd>C-w</kbd> <kbd>j/k/h/l</kbd>                            | Focus group below/above/left/right.                                                                                                                                                                                                                                                                                                                        |
-|                                | <kbd>C-w</kbd> <kbd>C-j/i/h/l</kbd>                          | Move editor to group below/above/left/right. Vim doesn't have analogue mappings. **Note**: <kbd>C-w</kbd> <kbd>C-i</kbd> moves editor up. Logically it should be <kbd>C-w</kbd> <kbd>C-k</kbd> but vscode has many commands mapped to <kbd>C-k</kbd> <kbd>[key]</kbd> and doesn't allow to use <kbd>C-w</kbd> <kbd>C-k</kbd> without unbinding them first. |
-|                                | <kbd>C-w</kbd> <kbd>r/R/x</kbd>                              | Not supported, use <kbd>C-w</kbd> <kbd>C-j</kbd> and similar to move editors.                                                                                                                                                                                                                                                                              |
-|                                | <kbd>C-w</kbd> <kbd>w</kbd> or <kbd>C-w</kbd> <kbd>C-w</kbd> | Focus next group. The behavior may differ than in vim.                                                                                                                                                                                                                                                                                                     |
-|                                | <kbd>C-w</kbd> <kbd>W</kbd> or <kbd>C-w</kbd> <kbd>p</kbd>   | Focus previous group. The behavior may differ than in vim. <kbd>C-w</kbd> <kbd>p</kbd> is completely different than in vim.                                                                                                                                                                                                                                |
-|                                | <kbd>C-w</kbd> <kbd>b</kbd>                                  | Focus last editor group (most bottom-right).                                                                                                                                                                                                                                                                                                               |
-|                                | <kbd>C-w</kbd> <kbd>H/K/J/L</kbd>                            | Not supported yet.                                                                                                                                                                                                                                                                                                                                         |
-|                                | <kbd>C-w</kbd> <kbd>=</kbd>                                  | Align all editors to have the same width.                                                                                                                                                                                                                                                                                                                  |
-|                                | <kbd>[count] C-w</kbd> <kbd>+</kbd>                          | Increase editor height by (optional) count.                                                                                                                                                                                                                                                                                                                |
-|                                | <kbd>[count] C-w</kbd> <kbd>-</kbd>                          | Decrease editor height by (optional) count.                                                                                                                                                                                                                                                                                                                |
-|                                | <kbd>[count] C-w</kbd> <kbd>></kbd>                          | Increase editor width by (optional) count.                                                                                                                                                                                                                                                                                                                 |
-|                                | <kbd>[count] C-w</kbd> <kbd>\<</kbd>                         | Decrease editor width by (optional) count.                                                                                                                                                                                                                                                                                                                 |
-|                                | <kbd>C-w</kbd> <kbd>\_</kbd>                                 | Toggle maximized editor size. Pressing again will restore the size.                                                                                                                                                                                                                                                                                        |
+| Command    | Key                                                                                     | Description                                                                                                                                                                                                                                                                                                                                                |
+| ---------- | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sp[lit]`  | <kbd>C-w</kbd> <kbd>s</kbd> <span style="display: inline-block; width:11em">text</span> | Split editor horizontally. <br/> With argument: open the specified file, e.g `:sp $MYVIMRC`. File must exist.                                                                                                                                                                                                                                              |
+| `vs[plit]` | <kbd>C-w</kbd> <kbd>v</kbd>                                                             | Split editor vertically. <br/> With argument: open the specified file. File must exist.                                                                                                                                                                                                                                                                    |
+| `new`      | <kbd>C-w</kbd> <kbd>n</kbd>                                                             | Like `sp[lit]` but create new untitled file if no argument given.                                                                                                                                                                                                                                                                                          |
+| `vne[w]`   |                                                                                         | Like `vs[plit]` but create new untitled file if no argument given.                                                                                                                                                                                                                                                                                         |
+| `on[ly]`   | <kbd>C-w</kbd> <kbd>o</kbd>                                                             | Without bang: merge all editor groups into the one. Don't close editors. <br/> With bang: close all editors from all groups except current one.                                                                                                                                                                                                            |
+|            | <kbd>C-w</kbd> <kbd>j/k/h/l</kbd>                                                       | Focus group below/above/left/right.                                                                                                                                                                                                                                                                                                                        |
+|            | <kbd>C-w</kbd> <kbd>C-j/i/h/l</kbd>                                                     | Move editor to group below/above/left/right. Vim doesn't have analogue mappings. **Note**: <kbd>C-w</kbd> <kbd>C-i</kbd> moves editor up. Logically it should be <kbd>C-w</kbd> <kbd>C-k</kbd> but vscode has many commands mapped to <kbd>C-k</kbd> <kbd>[key]</kbd> and doesn't allow to use <kbd>C-w</kbd> <kbd>C-k</kbd> without unbinding them first. |
+|            | <kbd>C-w</kbd> <kbd>r/R/x</kbd>                                                         | Not supported, use <kbd>C-w</kbd> <kbd>C-j</kbd> and similar to move editors.                                                                                                                                                                                                                                                                              |
+|            | <kbd>C-w</kbd> <kbd>w</kbd> or <kbd>C-w</kbd> <kbd>C-w</kbd>                            | Focus next group. The behavior may differ than in vim.                                                                                                                                                                                                                                                                                                     |
+|            | <kbd>C-w</kbd> <kbd>W</kbd> or <kbd>C-w</kbd> <kbd>p</kbd>                              | Focus previous group. The behavior may differ than in vim. <kbd>C-w</kbd> <kbd>p</kbd> is completely different than in vim.                                                                                                                                                                                                                                |
+|            | <kbd>C-w</kbd> <kbd>b</kbd>                                                             | Focus last editor group (most bottom-right).                                                                                                                                                                                                                                                                                                               |
+|            | <kbd>C-w</kbd> <kbd>H/K/J/L</kbd>                                                       | Not supported yet.                                                                                                                                                                                                                                                                                                                                         |
+|            | <kbd>C-w</kbd> <kbd>=</kbd>                                                             | Align all editors to have the same width.                                                                                                                                                                                                                                                                                                                  |
+|            | <kbd>[count]</kbd> <kbd>C-w</kbd> <kbd>+</kbd>                                          | Increase editor height by (optional) count.                                                                                                                                                                                                                                                                                                                |
+|            | <kbd>[count]</kbd> <kbd>C-w</kbd> <kbd>-</kbd>                                          | Decrease editor height by (optional) count.                                                                                                                                                                                                                                                                                                                |
+|            | <kbd>[count]</kbd> <kbd>C-w</kbd> <kbd>></kbd>                                          | Increase editor width by (optional) count.                                                                                                                                                                                                                                                                                                                 |
+|            | <kbd>[count]</kbd> <kbd>C-w</kbd> <kbd>\<</kbd>                                         | Decrease editor width by (optional) count.                                                                                                                                                                                                                                                                                                                 |
+|            | <kbd>C-w</kbd> <kbd>\_</kbd>                                                            | Toggle maximized editor size. Pressing again will restore the size.                                                                                                                                                                                                                                                                                        |
 
 To use VSCode command 'Increase/decrease current view size' instead of separate bindings for width and height:
 
@@ -403,25 +399,25 @@ To use VSCode command 'Increase/decrease current view size' instead of separate 
 
 ### Insert mode special keys
 
-Enabled by `useCtrlKeysForInsertMode = true` (default true).
+Enabled by `useCtrlKeysForInsertMode` (default true).
 
-| Key                              | Description                                                       | Status                            |
-| -------------------------------- | ----------------------------------------------------------------- | --------------------------------- |
-| <kbd>C-r [0-9a-z"%#*+:.-=]</kbd> | Paste from register                                               | Works                             |
-| <kbd>C-a</kbd>                   | Paste previous inserted content                                   | Works                             |
-| <kbd>C-u</kbd>                   | Delete all text till beginning of line, if empty - delete newline | Bound to VSCode key               |
-| <kbd>C-w</kbd>                   | Delete word left                                                  | Bound to VSCode key               |
-| <kbd>C-h</kbd>                   | Delete character left                                             | Bound to VSCode key               |
-| <kbd>C-t</kbd>                   | Indent lines right                                                | Bound to VSCode indent line       |
-| <kbd>C-d</kbd>                   | Indent lines left                                                 | Bound to VSCode outindent line    |
-| <kbd>C-j</kbd>                   | Insert line                                                       | Bound to VSCode insert line after |
-| <kbd>C-c</kbd>                   | Escape                                                            | Works                             |
+| Key                                         | Description                                                       | Status                            |
+| ------------------------------------------- | ----------------------------------------------------------------- | --------------------------------- |
+| <kbd>C-r</kbd> <kbd>[0-9a-z"%#*+:.-=]</kbd> | Paste from register                                               | Works                             |
+| <kbd>C-a</kbd>                              | Paste previous inserted content                                   | Works                             |
+| <kbd>C-u</kbd>                              | Delete all text till beginning of line, if empty - delete newline | Bound to VSCode key               |
+| <kbd>C-w</kbd>                              | Delete word left                                                  | Bound to VSCode key               |
+| <kbd>C-h</kbd>                              | Delete character left                                             | Bound to VSCode key               |
+| <kbd>C-t</kbd>                              | Indent lines right                                                | Bound to VSCode indent line       |
+| <kbd>C-d</kbd>                              | Indent lines left                                                 | Bound to VSCode outindent line    |
+| <kbd>C-j</kbd>                              | Insert line                                                       | Bound to VSCode insert line after |
+| <kbd>C-c</kbd>                              | Escape                                                            | Works                             |
 
 Other keys are not supported in insert mode.
 
 ### Normal mode control keys
 
-Enabled by `useCtrlKeysForNormalMode = true` (default true).
+Enabled by `useCtrlKeysForNormalMode` (default true).
 
 Refer to vim manual for their use.
 
@@ -447,33 +443,35 @@ Refer to vim manual for their use.
 -   <kbd>C-h</kbd>
 -   <kbd>C-/</kbd>
 
-### Cmdline control keys (always enabled)
+### Cmdline special keys
 
-| Key                             | Desription                                                |
-| ------------------------------- | --------------------------------------------------------- |
-| <kbd>C-h</kbd>                  | Delete one character left.                                |
-| <kbd>C-w</kbd>                  | Delete word left.                                         |
-| <kbd>C-u</kbd>                  | Clear line.                                               |
-| <kbd>C-g</kbd> / <kbd>C-t</kbd> | In incsearch mode moves to next/previous result.          |
-| <kbd>C-l</kbd>                  | Add next character under the cursor to incsearch.         |
-| <kbd>C-n</kbd> / <kbd>C-p</kbd> | Go down/up history.                                       |
-| <kbd>Up</kbd>/<kbd>Down</kbd>   | Select next/prev suggestion (cannot be used for history). |
-| <kbd>Tab</kbd>                  | Select suggestion.                                        |
+Always enabled.
 
-### VSCode navigation bindings
+| Key                             | Desription                                                                                                                                                                               |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <kbd>C-h</kbd>                  | Delete one character left.                                                                                                                                                               |
+| <kbd>C-w</kbd>                  | Delete word left.                                                                                                                                                                        |
+| <kbd>C-u</kbd>                  | Clear line.                                                                                                                                                                              |
+| <kbd>C-g</kbd> / <kbd>C-t</kbd> | In incsearch mode moves to next/previous result.                                                                                                                                         |
+| <kbd>C-l</kbd>                  | Add next character under the cursor to incsearch.                                                                                                                                        |
+| <kbd>C-n</kbd> / <kbd>C-p</kbd> | Go down/up history. <br/> `list.focusDown` <br/> `showNextParameterHint` <br/> `selectNextSuggestion` <br/> `workbench.action.quickOpenSelectNext` <br/> (including the other direction) |
+| <kbd>Up</kbd> / <kbd>Down</kbd> | Select next/prev suggestion (cannot be used for history).                                                                                                                                |
+| <kbd>Tab</kbd>                  | Select suggestion.                                                                                                                                                                       |
+
+### VSCode specific bindings
 
 #### Explorer/list navigation
 
-| Key                            | VSCode Command                  |
-| ------------------------------ | ------------------------------- |
-| <kbd>j</kbd>/<kbd>k</kbd>      | `list.focusDown/Up`             |
-| <kbd>h</kbd>/<kbd>l</kbd>      | `list.collapse/select`          |
-| <kbd>Enter</kbd>               | `list.select`                   |
-| <kbd>gg</kbd>                  | `list.focusFirst`               |
-| <kbd>G</kbd>                   | `list.focusLast`                |
-| <kbd>o</kbd>                   | `list.toggleExpand`             |
-| <kbd>C-u</kbd>/<kbd>C-d</kbd>  | `list.focusPageUp/Down`         |
-| <kbd>/</kbd>/<kbd>Escape</kbd> | `list.toggleKeyboardNavigation` |
+| Key                                | VSCode Command                  |
+| ---------------------------------- | ------------------------------- |
+| <kbd>j</kbd> / <kbd>k</kbd>        | `list.focusDown/Up`             |
+| <kbd>h</kbd> / <kbd>l</kbd>        | `list.collapse/select`          |
+| <kbd>Enter</kbd>                   | `list.select`                   |
+| <kbd>gg</kbd>                      | `list.focusFirst`               |
+| <kbd>G</kbd>                       | `list.focusLast`                |
+| <kbd>o</kbd>                       | `list.toggleExpand`             |
+| <kbd>C-u</kbd> / <kbd>C-d</kbd>    | `list.focusPageUp/Down`         |
+| <kbd> / </kbd> / <kbd>Escape</kbd> | `list.toggleKeyboardNavigation` |
 
 #### Explorer file manipulation
 
@@ -487,6 +485,22 @@ Refer to vim manual for their use.
 | <kbd>v</kbd> | `explorer.openToSide` |
 | <kbd>a</kbd> | `explorer.newFile`    |
 | <kbd>A</kbd> | `explorer.newFolder`  |
+
+#### Editor commands
+
+| Key                                                         | VSCode Command                                                              |
+| ----------------------------------------------------------- | --------------------------------------------------------------------------- |
+| <kbd>=</kbd> / <kbd>==</kbd>                                | `editor.action.formatSelection`                                             |
+| <kbd>gh</kbd> / <kbd>K</kbd>                                | `editor.action.showHover`                                                   |
+| <kbd>gd</kbd> / <kbd>C-]</kbd>                              | `editor.action.revealDefinition` <br/> Also works in vim help               |
+| <kbd>gf</kbd>                                               | `editor.action.revealDeclaration`                                           |
+| <kbd>gH</kbd>                                               | `editor.action.referenceSearch.trigger`                                     |
+| <kbd>gO</kbd>                                               | `workbench.action.gotoSymbol`                                               |
+| <kbd>C-w</kbd> <kbd>gd</kbd> / <kbd>C-w</kbd> <kbd>gf</kbd> | `editor.action.revealDefinitionAside`                                       |
+| <kbd>gD</kbd>                                               | `editor.action.peekDefinition`                                              |
+| <kbd>gF</kbd>                                               | `editor.action.peekDeclaration`                                             |
+| <kbd>Tab</kbd>                                              | `togglePeekWidgetFocus` <br/> Switch between peek editor and reference list |
+| <kbd>C-n</kbd> / <kbd>C-p</kbd>                             | `list.focusUp/Down` <br/> Navigate peek reference list                      |
 
 ### Custom keybindings
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@
 
 Real Neovim integration for Visual Studio Code.
 
-[Neovim](https://neovim.io/) is a fork of VIM to allow greater extensibility and integration. This extension uses a full embedded Neovim instance, no more half-complete VIM emulation! Control is given to VSCode for insert mode and window/buffer/file management, making the best use of both editors.
+[Neovim](https://neovim.io/) is a fork of VIM to allow greater extensibility and integration. This extension uses a full
+embedded Neovim instance, no more half-complete VIM emulation! Control is given to VSCode for insert mode and
+window/buffer/file management, making the best use of both editors.
 
 ## Features
 
@@ -24,47 +26,79 @@ Neovim 0.5.0-nightly or greater
 
 ## Installation
 
--   Install the [vscode-neovim](https://marketplace.visualstudio.com/items?itemName=asvetliakov.vscode-neovim) extension.
--   Install [Neovim](https://github.com/neovim/neovim/wiki/Installing-Neovim) **0.5.0 nightly** or greater. You can install neovim-0.5.0-nightly separately for just vscode, outside your system's package manager installation.
--   Set the neovim path in the extension settings. You must specify full path to neovim, like `"C:\Neovim\bin\nvim.exe"` or `"/usr/local/bin/nvim"`. The setting id is `"vscode-neovim.neovimExecutablePaths.win32/linux/darwin"`, depending on your system.
--   **Important:** If you already have big `init.vim` it is recommended to wrap existing settings & plugins with [`if !exists('g:vscode')`](#determining-if-running-in-vscode-in-your-initvim) to prevent potential problems. If you have any problems, try with empty `init.vim` first.
+-   Install the [vscode-neovim](https://marketplace.visualstudio.com/items?itemName=asvetliakov.vscode-neovim)
+    extension.
+-   Install [Neovim](https://github.com/neovim/neovim/wiki/Installing-Neovim) **0.5.0 nightly** or greater. You can
+    install neovim-0.5.0-nightly separately for just vscode, outside your system's package manager installation.
+-   Set the neovim path in the extension settings. You must specify full path to neovim, like `"C:\Neovim\bin\nvim.exe"`
+    or `"/usr/local/bin/nvim"`. The setting id is `"vscode-neovim.neovimExecutablePaths.win32/linux/darwin"`, depending
+    on your system.
+-   **Important:** If you already have big `init.vim` it is recommended to wrap existing settings & plugins with
+    [`if !exists('g:vscode')`](#determining-if-running-in-vscode-in-your-initvim) to prevent potential problems. If you
+    have any problems, try with empty `init.vim` first.
 
-> :warning: **Neovim 0.5+** is **required**. Any version lower than that won't work. Many linux distributions have an **old** version of neovim in their package repo - always check what version are you installing.
+> :warning: **Neovim 0.5+** is **required**. Any version lower than that won't work. Many linux distributions have an
+> **old** version of neovim in their package repo - always check what version are you installing.
 
-> :info: If you get `"Unable to init vscode-neovim: command 'type' already exists"` message, uninstall other VSCode extensions that register `type` command (i.e. [VSCodeVim](https://marketplace.visualstudio.com/items?itemName=vscodevim.vim) or [Overtype](https://marketplace.visualstudio.com/items?itemName=adammaras.overtype)).
+> :info: If you get `"Unable to init vscode-neovim: command 'type' already exists"` message, uninstall other VSCode
+> extensions that register `type` command (i.e.
+> [VSCodeVim](https://marketplace.visualstudio.com/items?itemName=vscodevim.vim) or
+> [Overtype](https://marketplace.visualstudio.com/items?itemName=adammaras.overtype)).
 
 #### WSL
 
-If you want to use neovim from WSL, set `useWSL` configuration toggle and specify linux path to nvim binary. `wsl.exe` windows binary and `wslpath` linux binary are required for this. `wslpath` must be available through `$PATH` linux env setting. Use `wsl --list` to check for the correct default linux distribution.
+If you want to use neovim from WSL, set `useWSL` configuration toggle and specify linux path to nvim binary. `wsl.exe`
+windows binary and `wslpath` linux binary are required for this. `wslpath` must be available through `$PATH` linux env
+setting. Use `wsl --list` to check for the correct default linux distribution.
 
 ## Tips and Features
 
 ### Important
 
--   Visual modes don't produce vscode selections. Any vscode commands expecting selection won't work. To round the corners, invoking the VSCode command picker from visual mode through the default hotkeys (<kbd>f1</kbd>/<kbd>ctrl/cmd+shift+p</kbd>) converts vim selection to real vscode selection. This conversion is done automatically for some commands like commenting and formatting.
--   If you're using some custom mapping for calling vscode commands that depends on real vscode selection, you can use `VSCodeNotifyRange`/`VSCodeNotifyRangePos` (the first one linewise, the latter characterwise) functions which will convert visual mode selection to vscode selection before calling the command. See [this for example](https://github.com/asvetliakov/vscode-neovim/blob/e61832119988bb1e73b81df72956878819426ce2/vim/vscode-code-actions.vim#L42-L54) and [mapping](https://github.com/asvetliakov/vscode-neovim/blob/e61832119988bb1e73b81df72956878819426ce2/vim/vscode-code-actions.vim#L98).
+-   Visual modes don't produce vscode selections. Any vscode commands expecting selection won't work. To round the
+    corners, invoking the VSCode command picker from visual mode through the default hotkeys
+    (<kbd>f1</kbd>/<kbd>ctrl/cmd+shift+p</kbd>) converts vim selection to real vscode selection. This conversion is done
+    automatically for some commands like commenting and formatting.
+-   If you're using some custom mapping for calling vscode commands that depends on real vscode selection, you can use
+    `VSCodeNotifyRange`/`VSCodeNotifyRangePos` (the first one linewise, the latter characterwise) functions which will
+    convert visual mode selection to vscode selection before calling the command. See
+    [this for example](https://github.com/asvetliakov/vscode-neovim/blob/e61832119988bb1e73b81df72956878819426ce2/vim/vscode-code-actions.vim#L42-L54)
+    and
+    [mapping](https://github.com/asvetliakov/vscode-neovim/blob/e61832119988bb1e73b81df72956878819426ce2/vim/vscode-code-actions.vim#L98).
 -   The extension works best if `editor.scrollBeyondLastLine` is disabled.
--   When you type some commands they may be substituted for the another, like `:write` will be replaced by `:Write`. This is normal.
--   File/tab/window management (`:w`/`:q`/etc) commands are substituted and mapped to vscode actions. If you're using some custom commands/custom mappings to them, you might need to rebind them to call vscode actions instead. See reference links below for examples if you want to use custom keybindings/commands. **DO NOT** use vim `:w`, etc in scripts/keybindings, they won't work.
--   On a Mac, the <kbd>h</kbd>, <kbd>j</kbd>, <kbd>k</kbd> and <kbd>l</kbd> movement keys may not repeat when held, to fix this open Terminal and execute the following command:
+-   When you type some commands they may be substituted for the another, like `:write` will be replaced by `:Write`.
+    This is normal.
+-   File/tab/window management (`:w`/`:q`/etc) commands are substituted and mapped to vscode actions. If you're using
+    some custom commands/custom mappings to them, you might need to rebind them to call vscode actions instead. See
+    reference links below for examples if you want to use custom keybindings/commands. **DO NOT** use vim `:w`, etc in
+    scripts/keybindings, they won't work.
+-   On a Mac, the <kbd>h</kbd>, <kbd>j</kbd>, <kbd>k</kbd> and <kbd>l</kbd> movement keys may not repeat when held, to
+    fix this open Terminal and execute the following command:
     `defaults write com.microsoft.VSCode ApplePressAndHoldEnabled -bool false`.
 
 ### VSCode specific differences
 
 -   <kbd>=</kbd>, <kbd>==</kbd> are mapped to `editor.action.formatSelection`
--   It's possible to call vscode commands from neovim. See `VSCodeCall/VSCodeNotify` vim functions in `vscode-neovim.vim` file. `VSCodeCall` is blocking request, while `VSCodeNotify` is not (see below).
+-   It's possible to call vscode commands from neovim. See `VSCodeCall/VSCodeNotify` vim functions in
+    `vscode-neovim.vim` file. `VSCodeCall` is blocking request, while `VSCodeNotify` is not (see below).
 -   Scrolling is done by VSCode side. <kbd>C-d</kbd>/<kbd>C-u</kbd>/etc are slightly different.
--   File management commands such as <kbd>e</kbd> / <kbd>w</kbd> / <kbd>q</kbd> / etc are mapped to corresponding vscode commands
-    and behavior may be different (see below).
--   <kbd>gd</kbd>/<kbd>C-]</kbd> are mapped to `editor.action.revealDefinition` (Shortcut `F12`), also <kbd>C-]</kbd> works
-    in vim help files.
+-   File management commands such as <kbd>e</kbd> / <kbd>w</kbd> / <kbd>q</kbd> / etc are mapped to corresponding vscode
+    commands and behavior may be different (see below).
+-   <kbd>gd</kbd>/<kbd>C-]</kbd> are mapped to `editor.action.revealDefinition` (Shortcut `F12`), also <kbd>C-]</kbd>
+    works in vim help files.
 -   <kbd>gf</kbd> is mapped to `editor.action.revealDeclaration`
 -   <kbd>gH</kbd> is mapped to `editor.action.referenceSearch.trigger`
--   <kbd>gD</kbd>/<kbd>gF</kbd> are mapped to `editor.action.peekDefinition` and `editor.action.peekDeclaration` respectively (opens in peek).
--   <kbd>C-w</kbd> <kbd>gd</kbd>/<kbd>C-w</kbd> <kbd>gf</kbd> are mapped to `editor.action.revealDefinitionAside` (original vim command -
-    open new tab and go to the file under cursor, but vscode/vim window/tabs metaphors are completely different, so it's useful to do slightly different thing here).
+-   <kbd>gD</kbd>/<kbd>gF</kbd> are mapped to `editor.action.peekDefinition` and `editor.action.peekDeclaration`
+    respectively (opens in peek).
+-   <kbd>C-w</kbd> <kbd>gd</kbd>/<kbd>C-w</kbd> <kbd>gf</kbd> are mapped to `editor.action.revealDefinitionAside`
+    (original vim command - open new tab and go to the file under cursor, but vscode/vim window/tabs metaphors are
+    completely different, so it's useful to do slightly different thing here).
 -   <kbd>gh</kbd> is mapped to `editor.action.showHover`
--   Dot-repeat (<kbd>.</kbd>). Moving cursor within a change range won't break the repeat sequence. In neovim, if you type `abc<cursor>` in insert mode, then move cursor to `a<cursor>bc` and type `1` here the repeat sequence would be `1`. However in vscode it would be `a1bc`. Another difference is that when you delete some text in insert mode, dot repeat only works from right-to-left, meaning it will treat <kbd>Del</kbd> key as <kbd>BS</kbd> keys when running dot repeat.
+-   Dot-repeat (<kbd>.</kbd>). Moving cursor within a change range won't break the repeat sequence. In neovim, if you
+    type `abc<cursor>` in insert mode, then move cursor to `a<cursor>bc` and type `1` here the repeat sequence would be
+    `1`. However in vscode it would be `a1bc`. Another difference is that when you delete some text in insert mode, dot
+    repeat only works from right-to-left, meaning it will treat <kbd>Del</kbd> key as <kbd>BS</kbd> keys when running
+    dot repeat.
 
 ### Performance problems
 
@@ -76,15 +110,23 @@ If you have any performance problems (cursor jitter usually) make sure you're no
 -   Anything that renders decorators/put something into vscode gutter very often, e.g. on each cursor/line move
 -   VSCode extensions that delay the extension host like "Bracket Pair Colorizer"
 
-Such extension may be fine and work well, but combined with any extension which should control the cursor position (such as any vim extension) it may work very bad, due to shared vscode extension host between all extensions (E.g. one extension is taking the control over the host and blocking the other extension, this produces jitter).
+Such extension may be fine and work well, but combined with any extension which should control the cursor position (such
+as any vim extension) it may work very bad, due to shared vscode extension host between all extensions (E.g. one
+extension is taking the control over the host and blocking the other extension, this produces jitter).
 
-If you're not sure, disable all other extensions except mine, **reload vscode/window** and see if the problem persist before reporting.
+If you're not sure, disable all other extensions except mine, **reload vscode/window** and see if the problem persist
+before reporting.
 
-Also there are reports that some vim settings/vim plugins increase latency and cause performance problems. Make sure you've disabled unneeded plugins. Many of them don't make sense with vscode and may cause problems. You don't need any code, highlighting, completion, lsp plugins as well any plugins that spawn windows/buffers (nerdtree and similar), fuzzy-finders plugins, etc. You might want to keep navigation/text-objects/text-editing/etc plugins - they should be fine.
+Also there are reports that some vim settings/vim plugins increase latency and cause performance problems. Make sure
+you've disabled unneeded plugins. Many of them don't make sense with vscode and may cause problems. You don't need any
+code, highlighting, completion, lsp plugins as well any plugins that spawn windows/buffers (nerdtree and similar),
+fuzzy-finders plugins, etc. You might want to keep navigation/text-objects/text-editing/etc plugins - they should be
+fine.
 
 ### Custom escape keys
 
-Since VSCode is responsible for insert mode, custom insert-mode vim mappings don't work. To map composite escape keys, put into your keybindings.json:
+Since VSCode is responsible for insert mode, custom insert-mode vim mappings don't work. To map composite escape keys,
+put into your keybindings.json:
 
 for <kbd>jj</kbd>
 
@@ -120,10 +162,11 @@ else
 endif
 ```
 
-To conditionally enable plugins, `vim-plug` has a [few solutions](https://github.com/junegunn/vim-plug/wiki/tips#conditional-activation).
+To conditionally enable plugins, `vim-plug` has a
+[few solutions](https://github.com/junegunn/vim-plug/wiki/tips#conditional-activation).
 
-For example, using the `Cond` helper, you can do the following to conditionally activate plugins while having them all still installed
-([source](https://github.com/asvetliakov/vscode-neovim/issues/415#issuecomment-715533865)):
+For example, using the `Cond` helper, you can do the following to conditionally activate plugins while having them all
+still installed ([source](https://github.com/asvetliakov/vscode-neovim/issues/415#issuecomment-715533865)):
 
 ```vim
 " inside plug#begin:
@@ -135,14 +178,19 @@ Plug 'asvetliakov/vim-easymotion', Cond(exists('g:vscode'), { 'as': 'vsc-easymot
 
 ### Invoking vscode actions from neovim
 
-There are [few helper functions](https://github.com/asvetliakov/vscode-neovim/blob/ecd361ff1968e597e2500e8ce1108830e918cfb8/vim/vscode-neovim.vim#L17-L39) that could be used to invoke any vscode commands:
+There are
+[few helper functions](https://github.com/asvetliakov/vscode-neovim/blob/ecd361ff1968e597e2500e8ce1108830e918cfb8/vim/vscode-neovim.vim#L17-L39)
+that could be used to invoke any vscode commands:
 
--   `VSCodeNotify(command, ...)`/`VSCodeCall(command, ...)` - invokes vscode command with optional
-    arguments.
--   `VSCodeNotifyRange(command, line1, line2, leaveSelection ,...)`/`VSCodeCallRange(command, line1, line2, leaveSelection, ...)` - produces real vscode selection from line1 to line2 and invokes vscode command. Linewise. Put 1 for `leaveSelection` argument to leave vscode selection after invoking the command.
--   `VSCodeNotifyRangePos(command, line1, line2, pos1, pos2, leaveSelection ,...)`/`VSCodeCallRangePos(command, line1, line2, pos1, pos2, leaveSelection, ...)` - produces real vscode selection from line1.pos1 to line2.pos2 and invokes vscode command. Characterwise.
+-   `VSCodeNotify(command, ...)`/`VSCodeCall(command, ...)` - invokes vscode command with optional arguments.
+-   `VSCodeNotifyRange(command, line1, line2, leaveSelection ,...)`/`VSCodeCallRange(command, line1, line2, leaveSelection, ...)` -
+    produces real vscode selection from line1 to line2 and invokes vscode command. Linewise. Put 1 for `leaveSelection`
+    argument to leave vscode selection after invoking the command.
+-   `VSCodeNotifyRangePos(command, line1, line2, pos1, pos2, leaveSelection ,...)`/`VSCodeCallRangePos(command, line1, line2, pos1, pos2, leaveSelection, ...)` -
+    produces real vscode selection from line1.pos1 to line2.pos2 and invokes vscode command. Characterwise.
 
-Functions with `Notify` in name are non-blocking, the ones with `Call` are blocking. Generally **use Notify** unless you really need a blocking call.
+Functions with `Notify` in name are non-blocking, the ones with `Call` are blocking. Generally **use Notify** unless you
+really need a blocking call.
 
 _Examples_:
 
@@ -184,11 +232,14 @@ nnoremap <silent> <C-w>gd <Cmd>call VSCodeNotify('editor.action.revealDefinition
 
 ### Jumplist
 
-VSCode's jumplist is used instead of Neovim's. This is to make navigation caused by VSCode (mouse click, outline navigation, jump to definition, ect) be navigable. Make sure to bind to `workbench.action.navigateBack` / `workbench.action.navigateForward` if you're using custom mappings. Marks (both upper & lowercased) should be fine.
+VSCode's jumplist is used instead of Neovim's. This is to make navigation caused by VSCode (mouse click, outline
+navigation, jump to definition, ect) be navigable. Make sure to bind to `workbench.action.navigateBack` /
+`workbench.action.navigateForward` if you're using custom mappings. Marks (both upper & lowercased) should be fine.
 
 ### Wildmenu completion
 
-Command menu has the wildmenu completion on type. The completion options appear after 1.5s (to not bother you when you write `:w` or `:noh`). <kbd>Up</kbd>/<kbd>Down</kbd> selects the option and <kbd>Tab</kbd> accepts it. See the gif:
+Command menu has the wildmenu completion on type. The completion options appear after 1.5s (to not bother you when you
+write `:w` or `:noh`). <kbd>Up</kbd>/<kbd>Down</kbd> selects the option and <kbd>Tab</kbd> accepts it. See the gif:
 
 ![wildmenu](/images/wildmenu.gif)
 
@@ -200,11 +251,15 @@ Multiple cursors work in:
 2. (Optional) Visual line mode
 3. (Optional) Visual block mode
 
-To spawn multiple cursors from visual line/block modes type <kbd>ma</kbd>/<kbd>mA</kbd> or <kbd>mi</kbd>/<kbd>mI</kbd> (by default). The effect differs:
+To spawn multiple cursors from visual line/block modes type <kbd>ma</kbd>/<kbd>mA</kbd> or <kbd>mi</kbd>/<kbd>mI</kbd>
+(by default). The effect differs:
 
--   For visual line mode <kbd>mi</kbd> will start insert mode on each selected line on the first non whitespace character and <kbd>ma</kbd> will on the end of line
--   For visual block mode <kbd>mi</kbd> will start insert on each selected line before the cursor block and <kbd>ma</kbd> after
--   <kbd>mA</kbd>/<kbd>mI</kbd> versions account empty lines too (only for visual line mode, for visual block mode they're same as <kbd>ma</kbd>/<kbd>mi</kbd>)
+-   For visual line mode <kbd>mi</kbd> will start insert mode on each selected line on the first non whitespace
+    character and <kbd>ma</kbd> will on the end of line
+-   For visual block mode <kbd>mi</kbd> will start insert on each selected line before the cursor block and
+    <kbd>ma</kbd> after
+-   <kbd>mA</kbd>/<kbd>mI</kbd> versions account empty lines too (only for visual line mode, for visual block mode
+    they're same as <kbd>ma</kbd>/<kbd>mi</kbd>)
 
 See gif in action:
 
@@ -212,9 +267,15 @@ See gif in action:
 
 ### Keyboard Quickfix
 
-By default, the quickfix menu can be opened using <kbd>z=</kbd> or <kbd>C-.</kbd>. However, it is currently [not possible](https://github.com/microsoft/vscode/issues/55111) to add mappings to the quickfix menu, so it can only be navigated with arrow keys. A [workaround vscode extension](https://marketplace.visualstudio.com/items?itemName=pascalsenn.keyboard-quickfix) has been made to use the quick open menu, which can be navigated with custom bindings.
+By default, the quickfix menu can be opened using <kbd>z=</kbd> or <kbd>C-.</kbd>. However, it is currently
+[not possible](https://github.com/microsoft/vscode/issues/55111) to add mappings to the quickfix menu, so it can only be
+navigated with arrow keys. A
+[workaround vscode extension](https://marketplace.visualstudio.com/items?itemName=pascalsenn.keyboard-quickfix) has been
+made to use the quick open menu, which can be navigated with custom bindings.
 
-To use, install the [keyboard-quickfix](https://marketplace.visualstudio.com/items?itemName=pascalsenn.keyboard-quickfix) extension, and add to your keybindings.json:
+To use, install the
+[keyboard-quickfix](https://marketplace.visualstudio.com/items?itemName=pascalsenn.keyboard-quickfix) extension, and add
+to your keybindings.json:
 
 ```jsonc
 {
@@ -269,7 +330,8 @@ Keys <kbd>ZZ</kbd> and <kbd>ZQ</kbd> are bound to `:wq` and `q!` respectively
 
 ### Buffer/window management
 
-_Note_: split size distribution is controlled by `workbench.editor.splitSizing` setting. By default, it's `distribute`, which is mapped to vim's `equalalways` and `eadirection = 'both'` (default).
+_Note_: split size distribution is controlled by `workbench.editor.splitSizing` setting. By default, it's `distribute`,
+which is mapped to vim's `equalalways` and `eadirection = 'both'` (default).
 
 | Command                        | Key                                                          | Description                                                                                                                                                                                                                                                                                                                                                |
 | ------------------------------ | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -440,11 +502,16 @@ Most vim plugins will work out of the box, but certain plugins may require some 
 
 ### Vim-easymotion
 
-While the original [vim-easymotion](https://github.com/easymotion/vim-easymotion) functions as expected, it works by replacing your text with markers then restoring back, which leads to broken text and many errors reported in VSCode.
+While the original [vim-easymotion](https://github.com/easymotion/vim-easymotion) functions as expected, it works by
+replacing your text with markers then restoring back, which leads to broken text and many errors reported in VSCode.
 
-For this reason I created the special [vim-easymotion fork](https://github.com/asvetliakov/vim-easymotion) which doesn't touch your text and instead use vscode text decorations. Just add my fork to your `vim-plug` block or by using your favorite vim plugin installer and delete original vim-easymotion. Also overwin motions won't work (obviously) so don't use them.
+For this reason I created the special [vim-easymotion fork](https://github.com/asvetliakov/vim-easymotion) which doesn't
+touch your text and instead use vscode text decorations. Just add my fork to your `vim-plug` block or by using your
+favorite vim plugin installer and delete original vim-easymotion. Also overwin motions won't work (obviously) so don't
+use them.
 
-By default, text decorations will appear behind of the associated text as shown in the screenshot. To show the decorations on top of the text, set `vscode-neovim.textDecorationsAtTop` to true.
+By default, text decorations will appear behind of the associated text as shown in the screenshot. To show the
+decorations on top of the text, set `vscode-neovim.textDecorationsAtTop` to true.
 
 Happy jumping!
 
@@ -452,7 +519,8 @@ Happy jumping!
 
 ### Vim-commentary
 
-You can use [vim-commentary](https://github.com/tpope/vim-commentary) if you like it. But vscode already has such functionality so why don't use it? Add to your init.vim/init.nvim:
+You can use [vim-commentary](https://github.com/tpope/vim-commentary) if you like it. But vscode already has such
+functionality so why don't use it? Add to your init.vim/init.nvim:
 
 ```vim
 xmap gc  <Plug>VSCodeCommentary
@@ -461,11 +529,13 @@ omap gc  <Plug>VSCodeCommentary
 nmap gcc <Plug>VSCodeCommentaryLine
 ```
 
-Similar to vim-commentary, gcc is comment line (accept count), use gc with motion/in visual mode. `VSCodeCommentary` is just a simple function which calls `editor.action.commentLine`.
+Similar to vim-commentary, gcc is comment line (accept count), use gc with motion/in visual mode. `VSCodeCommentary` is
+just a simple function which calls `editor.action.commentLine`.
 
 ### VIM quick-scope
 
-[quick-scope](https://github.com/unblevable/quick-scope) plugin uses default vim HL groups by default but they are normally ignored. To fix, add
+[quick-scope](https://github.com/unblevable/quick-scope) plugin uses default vim HL groups by default but they are
+normally ignored. To fix, add
 
 ```vim
 highlight QuickScopePrimary guifg='#afff5f' gui=underline ctermfg=155 cterm=underline
@@ -482,8 +552,10 @@ See [Issues section](https://github.com/asvetliakov/vscode-neovim/issues).
 
 -   VScode connects to neovim instance
 -   When opening a some file, a scratch buffer is created in nvim and being init with text content from vscode
--   Normal/visual mode commands are being sent directly to neovim. The extension listens for buffer events and applies edits from neovim
--   When entering the insert mode, the extensions stops listen for keystroke events and delegates typing mode to vscode (no neovim communication is being performed here)
+-   Normal/visual mode commands are being sent directly to neovim. The extension listens for buffer events and applies
+    edits from neovim
+-   When entering the insert mode, the extensions stops listen for keystroke events and delegates typing mode to vscode
+    (no neovim communication is being performed here)
 -   After pressing escape key from the insert mode, extension sends changes obtained from the insert mode to neovim
 
 ## Credits & External Resources

--- a/README.md
+++ b/README.md
@@ -7,55 +7,44 @@
 <a href="https://gitter.im/vscode-neovim/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge"><img src="https://badges.gitter.im/vscode-neovim/community.svg"></a>
 </p>
 
-Real Neovim integration for Visual Studio Code.
-
 [Neovim](https://neovim.io/) is a fork of VIM to allow greater extensibility and integration. This extension uses a full
-embedded Neovim instance, no more half-complete VIM emulation! Control is given to VSCode for insert mode and
-window/buffer/file management, making the best use of both editors.
+embedded Neovim instance, no more half-complete VIM emulation! VSCode's native functionality is used for insert mode and
+editor commands, making the best use of both editors.
 
-## Features
+-   🎉 Almost fully feature-complete VIM integration by utilizing neovim as a backend.
+-   🔧 Supports custom `init.vim` and many vim plugins.
+-   🥇 First-class and lag-free insert mode, letting VSCode do what it does best.
+-   🤝 Complete integration with VSCode features (lsp/autocompletion/snippets/multi-cursor/etc).
 
--   Almost fully feature-complete VIM integration by utilizing neovim as a backend.
--   Supports custom `init.vim` and many vim/neovim plugins.
--   First-class VSCode insert mode. The plugin unbinds self from the `type` event in insert mode, so no more typing lag.
--   Full integration with VSCode features - autocompletion/go to definition/snippets/multiple cursors/etc.
-
-## Requirements
-
-Neovim 0.5.0-nightly or greater
-
-## Installation
+## 🧰 Installation
 
 -   Install the [vscode-neovim](https://marketplace.visualstudio.com/items?itemName=asvetliakov.vscode-neovim)
     extension.
--   Install [Neovim](https://github.com/neovim/neovim/wiki/Installing-Neovim) **0.5.0 nightly** or greater. You can
-    install neovim-0.5.0-nightly separately for just vscode, outside your system's package manager installation.
--   Set the neovim path in the extension settings. You must specify full path to neovim, like `"C:\Neovim\bin\nvim.exe"`
-    or `"/usr/local/bin/nvim"`. The setting id is `"vscode-neovim.neovimExecutablePaths.win32/linux/darwin"`, depending
-    on your system.
--   **Important:** If you already have big `init.vim` it is recommended to wrap existing settings & plugins with
-    [`if !exists('g:vscode')`](#determining-if-running-in-vscode-in-your-initvim) to prevent potential problems. If you
-    have any problems, try with empty `init.vim` first.
+-   Install [Neovim](https://github.com/neovim/neovim/wiki/Installing-Neovim) **0.5.0 nightly** or greater.
+    -   You can install neovim separately for vscode, outside your system's package manager installation.
+    -   Set the neovim path in the extension settings. You must specify full path to neovim, like
+        "`C:\Neovim\bin\nvim.exe"` or "`/usr/local/bin/nvim`".
+    -   The setting id is "`vscode-neovim.neovimExecutablePaths.win32/linux/darwin`", respective to your system.
+-   If you want to use neovim from WSL, set the `useWSL` configuration toggle and specify linux path to nvim binary.
+    `wsl.exe` windows binary and `wslpath` linux binary are required for this. `wslpath` must be available through
+    `$PATH` linux env setting. Use `wsl --list` to check for the correct default linux distribution.
 
-> :warning: **Neovim 0.5+** is **required**. Any version lower than that won't work. Many linux distributions have an
-> **old** version of neovim in their package repo - always check what version are you installing.
+> ❗ **Neovim 0.5 nightly** or greater is **required**. Any version lower than that won't work. Many linux distributions
+> have an **old** version of neovim in their package repo - always check what version are you installing.
 
-> :info: If you get `"Unable to init vscode-neovim: command 'type' already exists"` message, uninstall other VSCode
-> extensions that register `type` command (i.e.
-> [VSCodeVim](https://marketplace.visualstudio.com/items?itemName=vscodevim.vim) or
+> ⚠️ If you get "Unable to init vscode-neovim: command 'type' already exists" message, uninstall other VSCode extensions
+> that register `type` command (i.e. [VSCodeVim](https://marketplace.visualstudio.com/items?itemName=vscodevim.vim) or
 > [Overtype](https://marketplace.visualstudio.com/items?itemName=adammaras.overtype)).
 
-#### WSL
-
-If you want to use neovim from WSL, set `useWSL` configuration toggle and specify linux path to nvim binary. `wsl.exe`
-windows binary and `wslpath` linux binary are required for this. `wslpath` must be available through `$PATH` linux env
-setting. Use `wsl --list` to check for the correct default linux distribution.
+> 💡 If you already have a big `init.vim` it is recommended to wrap existing settings & plugins with
+> [`if !exists('g:vscode')`](#determining-if-running-in-vscode-in-your-initvim) to prevent potential conflicts. If you
+> have any problems, try with empty `init.vim` first.
 
 ## Tips and Features
 
 ### Important
 
--   Visual modes don't produce vscode selections. Any vscode commands expecting selection won't work. To round the
+-   Visual modes don't produce vscode selections, so any vscode commands expecting selection won't work. To round the
     corners, invoking the VSCode command picker from visual mode through the default hotkeys
     (<kbd>f1</kbd>/<kbd>ctrl/cmd+shift+p</kbd>) converts vim selection to real vscode selection. This conversion is done
     automatically for some commands like commenting and formatting.
@@ -89,39 +78,31 @@ setting. Use `wsl --list` to check for the correct default linux distribution.
 -   <kbd>gf</kbd> is mapped to `editor.action.revealDeclaration`
 -   <kbd>gH</kbd> is mapped to `editor.action.referenceSearch.trigger`
 -   <kbd>gD</kbd>/<kbd>gF</kbd> are mapped to `editor.action.peekDefinition` and `editor.action.peekDeclaration`
-    respectively (opens in peek).
--   <kbd>C-w</kbd> <kbd>gd</kbd>/<kbd>C-w</kbd> <kbd>gf</kbd> are mapped to `editor.action.revealDefinitionAside`
-    (original vim command - open new tab and go to the file under cursor, but vscode/vim window/tabs metaphors are
-    completely different, so it's useful to do slightly different thing here).
+    respectively.
+-   <kbd>C-w</kbd> <kbd>gd</kbd>/<kbd>C-w</kbd> <kbd>gf</kbd> are mapped to `editor.action.revealDefinitionAside`.
 -   <kbd>gh</kbd> is mapped to `editor.action.showHover`
--   Dot-repeat (<kbd>.</kbd>). Moving cursor within a change range won't break the repeat sequence. In neovim, if you
-    type `abc<cursor>` in insert mode, then move cursor to `a<cursor>bc` and type `1` here the repeat sequence would be
-    `1`. However in vscode it would be `a1bc`. Another difference is that when you delete some text in insert mode, dot
-    repeat only works from right-to-left, meaning it will treat <kbd>Del</kbd> key as <kbd>BS</kbd> keys when running
-    dot repeat.
+-   Dot-repeat (<kbd>.</kbd>) is slightly different - moving the cursor within a change range won't break the repeat
+    sequence. In neovim, if you type `abc<cursor>` in insert mode, then move cursor to `a<cursor>bc` and type `1` here
+    the repeat sequence would be `1`. However in vscode it would be `a1bc`. Another difference is that when you delete
+    some text in insert mode, dot repeat only works from right-to-left, meaning it will treat <kbd>Del</kbd> key as
+    <kbd>BS</kbd> keys when running dot repeat.
 
 ### Performance problems
 
 If you have any performance problems (cursor jitter usually) make sure you're not using these kinds of extensions:
 
--   Line number extensions (VSCode has built-in support for normal/relative line numbers)
--   Indent guide extensions (VSCode has built-in indent guides)
--   Brackets highlighter extensions (VSCode has built-in feature)
--   Anything that renders decorators/put something into vscode gutter very often, e.g. on each cursor/line move
+-   Anything that renders decorators very often:
+    -   Line number extensions (VSCode has built-in support for normal/relative line numbers)
+    -   Indent guide extensions (VSCode has built-in indent guides)
+    -   Brackets highlighter extensions (VSCode has built-in feature)
 -   VSCode extensions that delay the extension host like "Bracket Pair Colorizer"
+-   VIM plugins that increase latency and cause performance problems. - Make sure to disable unneeded plugins, as many
+    of them don't make sense with vscode and may cause problems. - You don't need any code, highlighting, completion,
+    lsp plugins as well any plugins that spawn windows/buffers (nerdtree and similar), fuzzy-finders plugins, etc. - You
+    might want to keep navigation/text-objects/text-editing/etc plugins - they should be fine.
 
-Such extension may be fine and work well, but combined with any extension which should control the cursor position (such
-as any vim extension) it may work very bad, due to shared vscode extension host between all extensions (E.g. one
-extension is taking the control over the host and blocking the other extension, this produces jitter).
-
-If you're not sure, disable all other extensions except mine, **reload vscode/window** and see if the problem persist
-before reporting.
-
-Also there are reports that some vim settings/vim plugins increase latency and cause performance problems. Make sure
-you've disabled unneeded plugins. Many of them don't make sense with vscode and may cause problems. You don't need any
-code, highlighting, completion, lsp plugins as well any plugins that spawn windows/buffers (nerdtree and similar),
-fuzzy-finders plugins, etc. You might want to keep navigation/text-objects/text-editing/etc plugins - they should be
-fine.
+If you're not sure, disable all other extensions, **reload vscode/window** and see if the problem persists before
+reporting.
 
 ### Custom escape keys
 
@@ -163,10 +144,9 @@ endif
 ```
 
 To conditionally enable plugins, `vim-plug` has a
-[few solutions](https://github.com/junegunn/vim-plug/wiki/tips#conditional-activation).
-
-For example, using the `Cond` helper, you can do the following to conditionally activate plugins while having them all
-still installed ([source](https://github.com/asvetliakov/vscode-neovim/issues/415#issuecomment-715533865)):
+[few solutions](https://github.com/junegunn/vim-plug/wiki/tips#conditional-activation). For example, using the `Cond`
+helper, you can conditionally activate installed plugins
+([source](https://github.com/asvetliakov/vscode-neovim/issues/415#issuecomment-715533865)):
 
 ```vim
 " inside plug#begin:
@@ -176,21 +156,21 @@ Plug 'easymotion/vim-easymotion', Cond(!exists('g:vscode'))
 Plug 'asvetliakov/vim-easymotion', Cond(exists('g:vscode'), { 'as': 'vsc-easymotion' })
 ```
 
-### Invoking vscode actions from neovim
+### Invoking VSCode actions from neovim
 
 There are
 [few helper functions](https://github.com/asvetliakov/vscode-neovim/blob/ecd361ff1968e597e2500e8ce1108830e918cfb8/vim/vscode-neovim.vim#L17-L39)
 that could be used to invoke any vscode commands:
 
--   `VSCodeNotify(command, ...)`/`VSCodeCall(command, ...)` - invokes vscode command with optional arguments.
+-   `VSCodeNotify(command, ...)`/`VSCodeCall(command, ...)` - invoke vscode command with optional arguments.
 -   `VSCodeNotifyRange(command, line1, line2, leaveSelection ,...)`/`VSCodeCallRange(command, line1, line2, leaveSelection, ...)` -
-    produces real vscode selection from line1 to line2 and invokes vscode command. Linewise. Put 1 for `leaveSelection`
+    produce real linewise vscode selection from line1 to line2 and invoke vscode command. Put 1 for `leaveSelection`
     argument to leave vscode selection after invoking the command.
 -   `VSCodeNotifyRangePos(command, line1, line2, pos1, pos2, leaveSelection ,...)`/`VSCodeCallRangePos(command, line1, line2, pos1, pos2, leaveSelection, ...)` -
-    produces real vscode selection from line1.pos1 to line2.pos2 and invokes vscode command. Characterwise.
+    produce real characterwise vscode selection from line1.pos1 to line2.pos2 and invoke vscode command.
 
-Functions with `Notify` in name are non-blocking, the ones with `Call` are blocking. Generally **use Notify** unless you
-really need a blocking call.
+Functions with `Notify` in their name are non-blocking, the ones with `Call` are blocking. Generally **use Notify**
+unless you really need a blocking call.
 
 _Examples_:
 
@@ -232,9 +212,11 @@ nnoremap <silent> <C-w>gd <Cmd>call VSCodeNotify('editor.action.revealDefinition
 
 ### Jumplist
 
-VSCode's jumplist is used instead of Neovim's. This is to make navigation caused by VSCode (mouse click, outline
-navigation, jump to definition, ect) be navigable. Make sure to bind to `workbench.action.navigateBack` /
-`workbench.action.navigateForward` if you're using custom mappings. Marks (both upper & lowercased) should be fine.
+VSCode's jumplist is used instead of Neovim's. This is to make VSCode native navigation (mouse click, jump to
+definition, ect) navigable through the jumplist.
+
+Make sure to bind to `workbench.action.navigateBack` / `workbench.action.navigateForward` if you're using custom
+mappings. Marks (both upper & lowercased) should be fine.
 
 ### Wildmenu completion
 
@@ -255,11 +237,11 @@ To spawn multiple cursors from visual line/block modes type <kbd>ma</kbd>/<kbd>m
 (by default). The effect differs:
 
 -   For visual line mode <kbd>mi</kbd> will start insert mode on each selected line on the first non whitespace
-    character and <kbd>ma</kbd> will on the end of line
+    character and <kbd>ma</kbd> will on the end of line.
 -   For visual block mode <kbd>mi</kbd> will start insert on each selected line before the cursor block and
-    <kbd>ma</kbd> after
+    <kbd>ma</kbd> after.
 -   <kbd>mA</kbd>/<kbd>mI</kbd> versions account empty lines too (only for visual line mode, for visual block mode
-    they're same as <kbd>ma</kbd>/<kbd>mi</kbd>)
+    they're same as <kbd>ma</kbd>/<kbd>mi</kbd>).
 
 See gif in action:
 
@@ -302,29 +284,29 @@ nnoremap z= <Cmd>call VSCodeNotify('keyboard-quickfix.openQuickFix')<CR>
 
 ### File/Tab management
 
-| Command                                | Description                                                                                                                                                                                                                                                                                                                                                   |
-| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `:e[dit]` or `ex`                      | Without argument and without bang (`!`): opens quickopen window. <br/> Without argument and with bang: opens open file dialog. <br/> With filename, e.g. `:e $MYVIMRC`: opens a file in new tab. The file must exist. <br/> With filename and with bang e.g. `:e! $MYVIMRC`: closes current file (discard any changes) and opens a file. The file must exist. |
-| `ene[w]`                               | Without bang: creates new untitled document in vscode. <br/> With bang: closes current file (discard any changes) and creates new untitled document.                                                                                                                                                                                                          |
-| `fin[d]`                               | Opens vscode's quick open window. Arguments and count are not supported.                                                                                                                                                                                                                                                                                      |
-| `w[rite]`                              | Without bang (`!`) saves current file With bang opens 'save as' dialog                                                                                                                                                                                                                                                                                        |
-| `sav[eas]`                             | Opens 'save as' dialog.                                                                                                                                                                                                                                                                                                                                       |
-| `wa[ll]`                               | Saves all files. Bang is not doing anything.                                                                                                                                                                                                                                                                                                                  |
-| `q[uit]` or keys `<C-w> q` / `<C-w> c` | Closes the active editor.                                                                                                                                                                                                                                                                                                                                     |
-| `wq`                                   | Saves and closes the active editor.                                                                                                                                                                                                                                                                                                                           |
-| `qa[ll]`                               | Closes all editors, but doesn't quit vscode. Acts like `qall!`, so beware for a nonsaved changes.                                                                                                                                                                                                                                                             |
-| `wqa[ll]`/`xa[ll]`                     | Saves all editors & close.                                                                                                                                                                                                                                                                                                                                    |
-| `tabe[dit]`                            | Similar to `e[dit]`. Without argument opens quickopen, with argument opens the file in new tab.                                                                                                                                                                                                                                                               |
-| `tabnew`                               | Opens new untitled file.                                                                                                                                                                                                                                                                                                                                      |
-| `tabf[ind]`                            | Opens quickopen window.                                                                                                                                                                                                                                                                                                                                       |
-| `tab`/`tabs`                           | Not supported. Doesn't make sense with vscode.                                                                                                                                                                                                                                                                                                                |
-| `tabc[lose]`                           | Closes active editor (tab).                                                                                                                                                                                                                                                                                                                                   |
-| `tabo[nly]`                            | Closes other tabs in vscode **group** (pane). This differs from vim where a `tab` is a like a new window, but doesn't make sense in vscode.                                                                                                                                                                                                                   |
-| `tabn[ext]` or key `gt`                | Switches to next (or `count` tabs if argument is given) in the active vscode **group** (pane).                                                                                                                                                                                                                                                                |
-| `tabp[revious]` or key `gT`            | Switches to previous (or `count` tabs if argument is given) in the active vscode **group** (pane).                                                                                                                                                                                                                                                            |
-| `tabfir[st]`                           | Switches to the first tab in the active editor group.                                                                                                                                                                                                                                                                                                         |
-| `tabl[ast]`                            | Switches to the last tab in the active edtior group.                                                                                                                                                                                                                                                                                                          |
-| `tabm[ove]`                            | Not supported yet.                                                                                                                                                                                                                                                                                                                                            |
+| Command                                                               | Description                                                                                                                                                                                                                                                                                                                                                   |
+| --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `:e[dit]` or `ex`                                                     | Without argument and without bang (`!`): opens quickopen window. <br/> Without argument and with bang: opens open file dialog. <br/> With filename, e.g. `:e $MYVIMRC`: opens a file in new tab. The file must exist. <br/> With filename and with bang e.g. `:e! $MYVIMRC`: closes current file (discard any changes) and opens a file. The file must exist. |
+| `ene[w]`                                                              | Without bang: creates new untitled document in vscode. <br/> With bang: closes current file (discard any changes) and creates new untitled document.                                                                                                                                                                                                          |
+| `fin[d]`                                                              | Opens vscode's quick open window. Arguments and count are not supported.                                                                                                                                                                                                                                                                                      |
+| `w[rite]`                                                             | Without bang (`!`) saves current file. With bang opens 'save as' dialog.                                                                                                                                                                                                                                                                                      |
+| `sav[eas]`                                                            | Opens 'save as' dialog.                                                                                                                                                                                                                                                                                                                                       |
+| `wa[ll]`                                                              | Saves all files.                                                                                                                                                                                                                                                                                                                                              |
+| `q[uit]` or <kbd>C-w</kbd> <kbd>q</kbd> / <kbd>C-w</kbd> <kbd>c</kbd> | Closes the active editor.                                                                                                                                                                                                                                                                                                                                     |
+| `wq`                                                                  | Saves and closes the active editor.                                                                                                                                                                                                                                                                                                                           |
+| `qa[ll]`                                                              | Closes all editors, but doesn't quit vscode. Acts like `qall!`, so beware for nonsaved changes.                                                                                                                                                                                                                                                               |
+| `wqa[ll]`/`xa[ll]`                                                    | Saves all editors & close.                                                                                                                                                                                                                                                                                                                                    |
+| `tabe[dit]`                                                           | Similar to `e[dit]`. Without argument opens quickopen, with argument opens the file in new tab.                                                                                                                                                                                                                                                               |
+| `tabnew`                                                              | Opens new untitled file.                                                                                                                                                                                                                                                                                                                                      |
+| `tabf[ind]`                                                           | Opens quickopen window.                                                                                                                                                                                                                                                                                                                                       |
+| `tab`/`tabs`                                                          | Not supported. Doesn't make sense with vscode.                                                                                                                                                                                                                                                                                                                |
+| `tabc[lose]`                                                          | Closes active editor (tab).                                                                                                                                                                                                                                                                                                                                   |
+| `tabo[nly]`                                                           | Closes other tabs in vscode **group** (pane). This differs from vim where a `tab` is a like a new window, but doesn't make sense in vscode.                                                                                                                                                                                                                   |
+| `tabn[ext]` or <kbd>gt</kbd>                                          | Switches to next (or `count` tabs if argument is given) in the active vscode **group** (pane).                                                                                                                                                                                                                                                                |
+| `tabp[revious]` or <kbd>gT</kbd>                                      | Switches to previous (or `count` tabs if argument is given) in the active vscode **group** (pane).                                                                                                                                                                                                                                                            |
+| `tabfir[st]`                                                          | Switches to the first tab in the active editor group.                                                                                                                                                                                                                                                                                                         |
+| `tabl[ast]`                                                           | Switches to the last tab in the active edtior group.                                                                                                                                                                                                                                                                                                          |
+| `tabm[ove]`                                                           | Not supported yet.                                                                                                                                                                                                                                                                                                                                            |
 
 Keys <kbd>ZZ</kbd> and <kbd>ZQ</kbd> are bound to `:wq` and `q!` respectively
 
@@ -453,7 +435,7 @@ Refer to vim manual for their use.
 | <kbd>gg</kbd>                  | `list.focusFirst`               |
 | <kbd>G</kbd>                   | `list.focusLast`                |
 | <kbd>o</kbd>                   | `list.toggleExpand`             |
-| <kbd>C-U</kbd>/<kbd>D</kbd>    | `list.focusPageUp/Down`         |
+| <kbd>C-u</kbd>/<kbd>C-d</kbd>  | `list.focusPageUp/Down`         |
 | <kbd>/</kbd>/<kbd>Escape</kbd> | `list.toggleKeyboardNavigation` |
 
 #### Explorer file manipulation:
@@ -471,9 +453,8 @@ Refer to vim manual for their use.
 
 ### Custom keybindings
 
-Control keys which are not in the above tables are not sent to neovim (as they are usually useless with vscode).
-
-To pass additional ctrl keys to neovim, for example <kbd>C-Tab</kbd>, add to your keybindings.json:
+Control keys which are not in the above tables are not sent to neovim by default. To pass additional ctrl keys to
+neovim, for example <kbd>C-Tab</kbd>, add to your keybindings.json:
 
 ```jsonc
 {
@@ -487,7 +468,7 @@ To pass additional ctrl keys to neovim, for example <kbd>C-Tab</kbd>, add to you
 }
 ```
 
-To disable existing ctrl key sequence, for example <kbd>C-A</kbd> add to your keybindings.json:
+To disable existing an ctrl key sequence, for example <kbd>C-A</kbd> add to your keybindings.json:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -208,183 +208,60 @@ See gif in action:
 
 ### File/Tab management commands
 
-`:e[dit]` or `ex`
-
--   `:e` without argument and without bang (`!`) - opens quickopen window
--   `:e!` without argument and with bang - opens open file dialog
--   `:e [filename]` , e.g. `:e $MYVIMRC` - opens a file in new tab. The file must exist
--   `:e! [filename]`, e.g. `:e! $MYVIMRC` - closes current file (discard any changes) and opens a file. The file must exist
-
-`ene[w]`
-
--   `enew` Creates new untitled document in vscode
--   `enew!` closes current file (discard any changes) and creates new untitled document
-
-`fin[d]`
-
--   Opens vscode's quick open window. Arguments and count are not supported
-
-`w[rite]`
-
--   Without bang (`!`) saves current file
--   With bang opens 'save as' dialog
-
-`sav[eas]`
-
--   Opens 'save as' dialog
-
-`wa[ll]`
-
--   Saves all files. Bang is not doing anything
-
-`q[uit]` or keys `<C-w> q` / `<C-w> c`
-
--   Closes the active editor
-
-`wq`
-
--   Saves and closes the active editor
-
-`qa[ll]`
-
--   Closes all editors, but doesn't quit vscode. Acts like `qall!`, so beware for a nonsaved changes
-
-`wqa[ll]`/`xa[ll]`
-
--   Saves all editors & close
-
-`tabe[dit]`
-
--   Similar to `e[dit]`. Without argument opens quickopen, with argument opens the file in new tab
-
-`tabnew`
-
--   Opens new untitled file
-
-`tabf[ind]`
-
--   Opens quickopen window
-
-`tab`/`tabs`
-
--   Not supported. Doesn't make sense with vscode
-
-`tabc[lose]`
-
--   Closes active editor (tab)
-
-`tabo[nly]`
-
--   Closes other tabs in vscode **group** (pane). This differs from vim where a `tab` is a like a new window, but doesn't make sense in vscode.
-
-`tabn[ext]` or key `gt`
-
--   Switches to next (or `count` tabs if argument is given) in the active vscode **group** (pane)
-
-`tabp[revious]` or key `gT`
-
--   Switches to previous (or `count` tabs if argument is given) in the active vscode **group** (pane)
-
-`tabfir[st]`
-
--   Switches to the first tab in the active editor group
-
-`tabl[ast]`
-
--   Switches to the last tab in the active edtior group
-
-`tabm[ove]`
-
--   Not supported yet
+| Command                                | Description                                                                                                                                                                                                                                                                                                                                                   |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `:e[dit]` or `ex`                      | Without argument and without bang (`!`): opens quickopen window. <br/> Without argument and with bang: opens open file dialog. <br/> With filename, e.g. `:e $MYVIMRC`: opens a file in new tab. The file must exist. <br/> With filename and with bang e.g. `:e! $MYVIMRC`: closes current file (discard any changes) and opens a file. The file must exist. |
+| `ene[w]`                               | Without bang: creates new untitled document in vscode. <br/> With bang: closes current file (discard any changes) and creates new untitled document.                                                                                                                                                                                                          |
+| `fin[d]`                               | Opens vscode's quick open window. Arguments and count are not supported.                                                                                                                                                                                                                                                                                      |
+| `w[rite]`                              | Without bang (`!`) saves current file With bang opens 'save as' dialog                                                                                                                                                                                                                                                                                        |
+| `sav[eas]`                             | Opens 'save as' dialog.                                                                                                                                                                                                                                                                                                                                       |
+| `wa[ll]`                               | Saves all files. Bang is not doing anything.                                                                                                                                                                                                                                                                                                                  |
+| `q[uit]` or keys `<C-w> q` / `<C-w> c` | Closes the active editor.                                                                                                                                                                                                                                                                                                                                     |
+| `wq`                                   | Saves and closes the active editor.                                                                                                                                                                                                                                                                                                                           |
+| `qa[ll]`                               | Closes all editors, but doesn't quit vscode. Acts like `qall!`, so beware for a nonsaved changes.                                                                                                                                                                                                                                                             |
+| `wqa[ll]`/`xa[ll]`                     | Saves all editors & close.                                                                                                                                                                                                                                                                                                                                    |
+| `tabe[dit]`                            | Similar to `e[dit]`. Without argument opens quickopen, with argument opens the file in new tab.                                                                                                                                                                                                                                                               |
+| `tabnew`                               | Opens new untitled file.                                                                                                                                                                                                                                                                                                                                      |
+| `tabf[ind]`                            | Opens quickopen window.                                                                                                                                                                                                                                                                                                                                       |
+| `tab`/`tabs`                           | Not supported. Doesn't make sense with vscode.                                                                                                                                                                                                                                                                                                                |
+| `tabc[lose]`                           | Closes active editor (tab).                                                                                                                                                                                                                                                                                                                                   |
+| `tabo[nly]`                            | Closes other tabs in vscode **group** (pane). This differs from vim where a `tab` is a like a new window, but doesn't make sense in vscode.                                                                                                                                                                                                                   |
+| `tabn[ext]` or key `gt`                | Switches to next (or `count` tabs if argument is given) in the active vscode **group** (pane).                                                                                                                                                                                                                                                                |
+| `tabp[revious]` or key `gT`            | Switches to previous (or `count` tabs if argument is given) in the active vscode **group** (pane).                                                                                                                                                                                                                                                            |
+| `tabfir[st]`                           | Switches to the first tab in the active editor group.                                                                                                                                                                                                                                                                                                         |
+| `tabl[ast]`                            | Switches to the last tab in the active edtior group.                                                                                                                                                                                                                                                                                                          |
+| `tabm[ove]`                            | Not supported yet.                                                                                                                                                                                                                                                                                                                                            |
 
 Keys `ZZ` and `ZQ` are bound to `:wq` and `q!` respectively
 
 ### Buffer/window management commands
 
-_Note_: split size distribution is controlled by `workbench.editor.splitSizing` setting. By default it's `distribute`, which is mapped to vim's `equalalways` and `eadirection = 'both'` (default)
+_Note_: split size distribution is controlled by `workbench.editor.splitSizing` setting. By default, it's `distribute`, which is mapped to vim's `equalalways` and `eadirection = 'both'` (default).
 
-`sp[lit]` or key `<C-w> s`
+| Command                        | Key                        | Description                                                                                                                                                                                                                                                                              |
+| ------------------------------ | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sp[lit]`                      | `<C-w> s`                  | Split editor horizontally. <br/> When argument given opens the specified file in the argument, e.g `:sp $MYVIMRC`. File must exist.                                                                                                                                                      |
+| `vs[plit]`                     | `<C-w> v`                  | Split editor vertically. <br/> When argument given opens the specified file in the argument. File must exist.                                                                                                                                                                            |
+| `new`                          | `<C-w> n`                  | Like `sp[lit]` but creates new untitled file if no argument given.                                                                                                                                                                                                                       |
+| `vne[w]`                       |                            | Like `vs[plit]` but creates new untitled file if no argument given.                                                                                                                                                                                                                      |
+|                                | `<C-w> ^`                  | Not supported yet.                                                                                                                                                                                                                                                                       |
+| `vert[ical]`/`lefta[bove]`/etc |                            | Not supported yet.                                                                                                                                                                                                                                                                       |
+| `on[ly]`                       | `<C-w> o`                  | Without bang (`!`): merges all editor groups into the one. **Doesn't** close editors. <br/> With bang: closes all editors from all groups except current one.                                                                                                                            |
+|                                | `<C-w> j/k/h/l`            | Focus group below/above/left/right.                                                                                                                                                                                                                                                      |
+|                                | `<C-w> <C-j/i/h/l>`        | Move editor to group below/above/left/right. Vim doesn't have analogue mappings. **Note**: `<C-w> <C-i>` moves editor up. Logically it should be `<C-w> <C-k>` but vscode has many commands mapped to `<C-k> [key]` and doesn't allow to use `<C-w> <C-k>` without unbinding them first. |
+|                                | `<C-w> r/R/x`              | Not supported, use `<C-w> <C-j>` and similar to move editors.                                                                                                                                                                                                                            |
+|                                | `<C-w> w` or `<C-w> <C-w>` | Focus next group. The behavior may differ than in vim.                                                                                                                                                                                                                                   |
+|                                | `<C-w> W` or `<C-w> p`     | Focus previous group. The behavior may differ than in vim. `<C-w> p` is completely different than in vim.                                                                                                                                                                                |
+|                                | `<C-w> b`                  | Focus last editor group (most bottom-right).                                                                                                                                                                                                                                             |
+|                                | `<C-w> H/K/J/L`            | Not supported yet.                                                                                                                                                                                                                                                                       |
+|                                | `<C-w> =`                  | Align all editors to have the same width.                                                                                                                                                                                                                                                |
+|                                | `[count]<C-w> +`           | Increase editor height by (optional) count.                                                                                                                                                                                                                                              |
+|                                | `[count]<C-w> -`           | Decrease editor height by (optional) count.                                                                                                                                                                                                                                              |
+|                                | `[count]<C-w> >`           | Increase editor width by (optional) count.                                                                                                                                                                                                                                               |
+|                                | `[count]<C-w> <`           | Decrease editor width by (optional) count.                                                                                                                                                                                                                                               |
+|                                | `<C-w> _`                  | Toggle maximized editor size. Pressing again will restore the size.                                                                                                                                                                                                                      |
 
--   Split editor horizontally. When argument given opens the specified file in the argument, e.g `:sp $MYVIMRC`. File must exist
-
-`vs[plit]` or key `<C-w> v`
-
--   Split editor vertically. When argument given opens the specified file in the argument. File must exist
-
-`new` or key `<C-w> n`
-
--   Like `sp[lit]` but creates new untitled file if no argument given
-
-`vne[w]`
-
--   Like `vs[plit]` but creates new untitled file if no argument given
-
-`<C-w> ^`
-
--   Not supported yet
-
-`vert[ical]`/`lefta[bove]`/etc...
-
--   Not supported yet
-
-`on[ly]` or key `<C-w> o`
-
--   Without bang (`!`) Merges all editor groups into the one. **Doesn't** close editors
--   With bang closes all editors from all groups except current one
-
-`<C-w> j/k/h/l`
-
--   Focus group below/above/left/right
-
-`<C-w> <C-j>/<C-i>/<C-h>/<C-l>`
-
--   Move editor to group below/above/left/right. Vim doesn't have analogue mappings. **Note**: `<C-w> <C-i>` moves editor up. Logically it should be `<C-w> <C-k>` but vscode has many commands mapped to `<C-k> [key]` and doesn't allow to use `<C-w> <C-k>` without unbinding them first
-
-`<C-w> r/R/x`
-
--   Not supported use `<C-w> <C-j>` and similar to move editors
-
-`<C-w> w` or `<C-w> <C-w>`
-
--   Focus next group. The behavior may differ than in vim
-
-`<C-w> W` or `<C-w> p`
-
--   Focus previous group. The behavior may differ than in vim. `<C-w> p` is completely different than in vim
-
-`<C-w> t`
-
--   Focus first editor group (most top-left)
-
-`<C-w> b`
-
--   Focus last editor group (most bottom-right)
-
-`<C-w> H/K/J/L`
-
--   Not supported yet
-
-`<C-w> =`
-
--   Align all editors to have the same width
-
-`[count]<C-w> +`
-
--   Increase editor height by (optional) count
-
-`[count]<C-w> -`
-
--   Decrease editor height by (optional) count
-
-`[count]<C-w> >`
-
--   Increase editor width by (optional) count
-
-`[count]<C-w> <`
-
--   Decrease editor width by (optional) count
-
-To use VSCode command 'Increase/decrease current view size'
+To use VSCode command 'Increase/decrease current view size' instead of separate bindings for width and height:
 
 -   `workbench.action.increaseViewSize`
 -   `workbench.action.decreaseViewSize`
@@ -410,11 +287,6 @@ To use VSCode command 'Increase/decrease current view size'
         xnoremap <C-w>- <Cmd>call <SID>manageEditorSize(v:count, 'decrease')<CR>
 
     </details>
-    <br>
-
-`<C-w> _`
-
--   Toggle maximized editor size. Pressing again will restore the size
 
 ### Insert mode special keys
 
@@ -440,39 +312,39 @@ Enabled by `useCtrlKeysForNormalMode = true` (default true).
 
 Refer to vim manual for their use.
 
--   CTRL-a
--   CTRL-b
--   CTRL-c
--   CTRL-d
--   CTRL-e
--   CTRL-f
--   CTRL-i
--   CTRL-o (see https://github.com/asvetliakov/vscode-neovim/issues/181#issuecomment-585264621)
--   CTRL-r
--   CTRL-u
--   CTRL-v
--   CTRL-w
--   CTRL-x
--   CTRL-y
--   CTRL-]
--   CTRL-j
--   CTRL-k
--   CTRL-l
--   CTRL-h
--   CTRL-/
+-   `CTRL-a`
+-   `CTRL-b`
+-   `CTRL-c`
+-   `CTRL-d`
+-   `CTRL-e`
+-   `CTRL-f`
+-   `CTRL-i`
+-   `CTRL-o` (see https://github.com/asvetliakov/vscode-neovim/issues/181#issuecomment-585264621)
+-   `CTRL-r`
+-   `CTRL-u`
+-   `CTRL-v`
+-   `CTRL-w`
+-   `CTRL-x`
+-   `CTRL-y`
+-   `CTRL-]`
+-   `CTRL-j`
+-   `CTRL-k`
+-   `CTRL-l`
+-   `CTRL-h`
+-   `CTRL-/`
 
 ### Cmdline control keys (always enabled)
 
-| Key                 | Desription                                                |
-| ------------------- | --------------------------------------------------------- |
-| `CTRL-h`            | Delete one character left.                                |
-| `CTRL-w`            | Delete word left.                                         |
-| `CTRL-u`            | Clear line.                                               |
-| `CTRL-g` / `CTRL-t` | In incsearch mode moves to next/previous result.          |
-| `CTRL-l`            | Add next character under the cursor to incsearch.         |
-| `CTRL-n` / `CTRL-p` | Go down/up history.                                       |
-| `<Up>`/`<Down>`     | Select next/prev suggestion (cannot be used for history). |
-| `Tab`               | Select suggestion.                                        |
+| Key                 | Desc                                                     |
+|---------------------|----------------------------------------------------------|
+| `CTRL-h`            | Delete one character left                                |
+| `CTRL-w`            | Delete word left                                         |
+| `CTRL-u`            | Clear line                                               |
+| `CTRL-g` / `CTRL-t` | In incsearch mode moves to next/previous result          |
+| `CTRL-l`            | Add next character under the cursor to incsearch         |
+| `CTRL-n` / `CTRL-p` | Go down/up history                                       |
+| `<Up>`/`<Down>`     | Select next/prev suggestion (cannot be used for history) |
+| `Tab`               | Select suggestion                                        |
 
 ### Custom keybindings
 

--- a/package.json
+++ b/package.json
@@ -453,6 +453,47 @@
                 "command": "list.toggleKeyboardNavigation",
                 "when": "listFocus && inputFocus && listSupportsKeyboardNavigation"
             },
+            {
+                "key": "r",
+                "command": "renameFile",
+                "when": "explorerViewletVisible && filesExplorerFocus && !explorerResourceIsRoot && !explorerResourceReadonly && !inputFocus"
+            },
+            {
+                "key": "d",
+                "command": "deleteFile",
+                "when": "explorerViewletVisible && filesExplorerFocus && !explorerResourceReadonly && !inputFocus"
+            },
+            {
+                "key": "y",
+                "command": "filesExplorer.copy",
+                "when": "explorerViewletVisible && filesExplorerFocus && !explorerResourceIsRoot && !inputFocus"
+            },
+            {
+                "key": "x",
+                "command": "filesExplorer.cut",
+                "when": "explorerViewletVisible && filesExplorerFocus && !explorerResourceIsRoot && !inputFocus"
+            },
+            {
+                "key": "p",
+                "command": "filesExplorer.paste",
+                "when": "explorerViewletVisible && filesExplorerFocus && !explorerResourceReadonly && !inputFocus"
+            },
+            {
+                "key": "v",
+                "command": "explorer.openToSide",
+                "when": "explorerViewletFocus && explorerViewletVisible && !inputFocus"
+            },
+            {
+                "key": "a",
+                "command": "explorer.newFile",
+                "when": "filesExplorerFocus && !inputFocus"
+            },
+            {
+                "key": "shift+a",
+                "command": "explorer.newFolder",
+                "when": "filesExplorerFocus && !inputFocus"
+            },
+            {
                 "command": "showNextParameterHint",
                 "key": "ctrl+n",
                 "when": "editorTextFocus && parameterHintsMultipleSignatures && parameterHintsVisible"

--- a/package.json
+++ b/package.json
@@ -731,6 +731,18 @@
             },
             {
                 "command": "vscode-neovim.send",
+                "key": "home",
+                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "args": "<Home>"
+            },
+            {
+                "command": "vscode-neovim.send",
+                "key": "end",
+                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "args": "<End>"
+            },
+            {
+                "command": "vscode-neovim.send",
                 "key": "ctrl+a",
                 "when": "editorTextFocus && neovim.init && neovim.mode != insert && neovim.ctrlKeysNormal",
                 "args": "<C-a>"

--- a/package.json
+++ b/package.json
@@ -536,7 +536,7 @@
             {
                 "command": "vscode-neovim.escape",
                 "key": "Escape",
-                "when": "editorTextFocus && neovim.init && !markersNavigationVisible && !parameterHintsVisible"
+                "when": "editorTextFocus && neovim.init && !markersNavigationVisible && !parameterHintsVisible && !referenceSearchVisible"
             },
             {
                 "command": "vscode-neovim.escape",
@@ -554,6 +554,26 @@
                 "key": "cmd+shift+o",
                 "when": "editorTextFocus && neovim.mode != insert",
                 "args": "gO"
+            },
+            {
+                "key": "tab",
+                "command": "togglePeekWidgetFocus",
+                "when": "inReferenceSearchEditor || referenceSearchVisible && neovim.mode == normal"
+            },
+            {
+                "key": "escape",
+                "command": "closeReferenceSearch",
+                "when": "inReferenceSearchEditor && !config.editor.stablePeek && neovim.mode == normal"
+            },
+            {
+                "key": "ctrl+p",
+                "command": "list.focusUp",
+                "when": "inReferenceSearchEditor && neovim.mode == normal"
+            },
+            {
+                "key": "ctrl+n",
+                "command": "list.focusDown",
+                "when": "inReferenceSearchEditor && neovim.mode == normal"
             },
             {
                 "command": "vscode-neovim.send",

--- a/package.json
+++ b/package.json
@@ -526,7 +526,12 @@
             {
                 "command": "vscode-neovim.escape",
                 "key": "ctrl+c",
-                "when": "editorTextFocus && neovim.init"
+                "when": "editorTextFocus && neovim.init && neovim.mode != insert && neovim.ctrlKeysNormal"
+            },
+            {
+                "command": "vscode-neovim.escape",
+                "key": "ctrl+c",
+                "when": "editorTextFocus && neovim.init && neovim.mode == insert && neovim.ctrlKeysInsert"
             },
             {
                 "command": "vscode-neovim.escape",

--- a/package.json
+++ b/package.json
@@ -544,18 +544,6 @@
                 "when": "editorTextFocus && neovim.init"
             },
             {
-                "command": "vscode-neovim.send",
-                "key": "ctrl+shift+o",
-                "when": "editorTextFocus && neovim.mode != insert",
-                "args": "gO"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "cmd+shift+o",
-                "when": "editorTextFocus && neovim.mode != insert",
-                "args": "gO"
-            },
-            {
                 "key": "tab",
                 "command": "togglePeekWidgetFocus",
                 "when": "inReferenceSearchEditor || referenceSearchVisible && neovim.mode == normal"

--- a/package.json
+++ b/package.json
@@ -394,6 +394,65 @@
                 "when": "listFocus && !inputFocus"
             },
             {
+                "key": "j",
+                "command": "list.focusDown",
+                "when": "listFocus && !inputFocus"
+            },
+            {
+                "key": "k",
+                "command": "list.focusUp",
+                "when": "listFocus && !inputFocus"
+            },
+            {
+                "key": "h",
+                "command": "list.collapse",
+                "when": "listFocus && !inputFocus"
+            },
+            {
+                "key": "l",
+                "command": "list.select",
+                "when": "listFocus && !inputFocus"
+            },
+            {
+                "key": "enter",
+                "command": "list.select",
+                "when": "listFocus && !inputFocus"
+            },
+            {
+                "key": "g g",
+                "command": "list.focusFirst",
+                "when": "listFocus && !inputFocus"
+            },
+            {
+                "key": "shift+g",
+                "command": "list.focusLast",
+                "when": "listFocus && !inputFocus"
+            },
+            {
+                "key": "o",
+                "command": "list.toggleExpand",
+                "when": "listFocus && !inputFocus"
+            },
+            {
+                "key": "ctrl+u",
+                "command": "list.focusPageUp",
+                "when": "listFocus && !inputFocus"
+            },
+            {
+                "key": "ctrl+d",
+                "command": "list.focusPageDown",
+                "when": "listFocus && !inputFocus"
+            },
+            {
+                "key": "/",
+                "command": "list.toggleKeyboardNavigation",
+                "when": "listFocus && !inputFocus && listSupportsKeyboardNavigation"
+            },
+            {
+                "key": "escape",
+                "command": "list.toggleKeyboardNavigation",
+                "when": "listFocus && inputFocus && listSupportsKeyboardNavigation"
+            },
                 "command": "showNextParameterHint",
                 "key": "ctrl+n",
                 "when": "editorTextFocus && parameterHintsMultipleSignatures && parameterHintsVisible"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-neovim",
-    "displayName": "Neo Vim",
-    "description": "Real VIM in your Visual Studio Code",
+    "displayName": "VSCode Neovim",
+    "description": "VSCode Neovim Integration",
     "icon": "images/icon.png",
     "publisher": "asvetliakov",
     "extensionKind": [

--- a/vim/vscode-code-actions.vim
+++ b/vim/vscode-code-actions.vim
@@ -88,5 +88,9 @@ xnoremap <C-w>gd <Cmd>call VSCodeNotify('editor.action.revealDefinitionAside')<C
 xnoremap <expr> <C-/> <SID>vscodeCommentary()
 nnoremap <expr> <C-/> <SID>vscodeCommentary() . '_'
 
+" open quickfix menu for spelling corrections and refactoring
+" only keyboard arrows can be used to navigate, for a solution, see https://github.com/asvetliakov/vscode-neovim#keyboard-quickfix
+nnoremap z= <Cmd>call VSCodeNotify('editor.action.quickFix')<CR>
+
 " workaround for calling command picker in visual mode
 xnoremap <C-P> <Cmd>call <SID>openVSCodeCommandsInVisualMode()<CR>

--- a/vim/vscode-code-actions.vim
+++ b/vim/vscode-code-actions.vim
@@ -33,11 +33,6 @@ function! s:vscodeGoToDefinition(str)
     endif
 endfunction
 
-function! s:vscodeNotifyWithMark(command)
-  normal! m'
-  call VSCodeNotify(a:command)
-endfunction
-
 function! s:openVSCodeCommandsInVisualMode()
     let mode = mode()
     if mode ==# 'V'
@@ -68,7 +63,7 @@ nnoremap gh <Cmd>call VSCodeNotify('editor.action.showHover')<CR>
 nnoremap gf <Cmd>call <SID>vscodeGoToDefinition("Declaration")<CR>
 nnoremap gd <Cmd>call <SID>vscodeGoToDefinition("Definition")<CR>
 nnoremap <C-]> <Cmd>call <SID>vscodeGoToDefinition("Definition")<CR>
-nnoremap gO <Cmd>call <SID>vscodeNotifyWithMark('workbench.action.gotoSymbol')<CR>
+nnoremap gO <Cmd>call VSCodeNotify('workbench.action.gotoSymbol')<CR>
 nnoremap gF <Cmd>call VSCodeNotify('editor.action.peekDeclaration')<CR>
 nnoremap gD <Cmd>call VSCodeNotify('editor.action.peekDefinition')<CR>
 nnoremap gH <Cmd>call VSCodeNotify('editor.action.referenceSearch.trigger')<CR>
@@ -78,7 +73,7 @@ xnoremap gh <Cmd>call VSCodeNotify('editor.action.showHover')<CR>
 xnoremap gf <Cmd>call <SID>vscodeGoToDefinition("Declaration")<CR>
 xnoremap gd <Cmd>call <SID>vscodeGoToDefinition("Definition")<CR>
 xnoremap <C-]> <Cmd>call <SID>vscodeGoToDefinition("Definition")<CR>
-xnoremap gO <Cmd>call <SID>vscodeNotifyWithMark('workbench.action.gotoSymbol')<CR>
+xnoremap gO <Cmd>call VSCodeNotify('workbench.action.gotoSymbol')<CR>
 xnoremap gF <Cmd>call VSCodeNotify('editor.action.peekDeclaration')<CR>
 xnoremap gD <Cmd>call VSCodeNotify('editor.action.peekDefinition')<CR>
 xnoremap gH <Cmd>call VSCodeNotify('editor.action.referenceSearch.trigger')<CR>

--- a/vim/vscode-jumplist.vim
+++ b/vim/vscode-jumplist.vim
@@ -1,4 +1,4 @@
-nnoremap <silent> <C-o> <Cmd>call VSCodeNotify("workbench.action.navigateBack")<CR>
-nnoremap <silent> <C-i> <Cmd>call VSCodeNotify("workbench.action.navigateForward")<CR>
-nnoremap <silent> <Tab> <Cmd>call VSCodeNotify("workbench.action.navigateForward")<CR>
+nnoremap <C-o> <Cmd>call VSCodeNotify("workbench.action.navigateBack")<CR>
+nnoremap <C-i> <Cmd>call VSCodeNotify("workbench.action.navigateForward")<CR>
+nnoremap <Tab> <Cmd>call VSCodeNotify("workbench.action.navigateForward")<CR>
 


### PR DESCRIPTION
This is my work in progress for refactoring keybindings and readme. I hope you agree with the changes, and I will explain some of the keybindings at a later time. For now, I just want to show my progress, and see if you have any suggestions or feedback.

Would it be better to split this into two PRs? I put them in one because the readme needs to be changed to reflect the keybindings anyways.

**Todo:**

- [x] Add list/tree navigation (fixes #457)
- [x] Add file explorer actions
- [x] Make C-C binding toggleable (fixes #440)
- [x] Add navigation in peek editor (also fixes #604 and fixes #534)
- [x] Send home and end keys (fixes #448)
- [x] Refactor readme design and sentences
- [x] Convert readme large binding list into table
- [x] Document new bindings
- [x] Change ext name to "VSCode Neovim"???
- [x] Add suggested vscode settings for best keyboard navigation
- [x] Document new peek mode bindings
- [x] Add table of contents
- [ ] Provide opinionated vscode UI navigation bindings?
- [ ] Or just provide link to blog posts where people make the vscode ui very keyboard-centric
- [ ] Embrace the new wiki, move tips information over, add example navigation bindings there? Maybe after the PR.

