### PR TITLE
Fix init error with no workspace folders open

### DIFF
--- a/src/main_controller.ts
+++ b/src/main_controller.ts
@@ -108,7 +108,7 @@ export class MainController implements vscode.Disposable {
         const neovimOptionScriptPath = path.posix.join(extensionPath, "vim", "vscode-options.vim");
 
         const workspaceFolder = vscode.workspace.workspaceFolders;
-        const cwd = workspaceFolder ? workspaceFolder[0].uri.fsPath : "~";
+        const cwd = workspaceFolder && workspaceFolder.length ? workspaceFolder[0].uri.fsPath : "~";
 
         const args = [
             "-N",


### PR DESCRIPTION
I am using VSCodium v1.52.1, not Microsoft VSCode, so this may not be an issue there.

vscode-neovim was failing to initialize for me in sessions with no workspace folders with the error `Unable to init vscode-neovim: Cannot read property 'uri' of undefined`

A quick search of the source led me to https://github.com/asvetliakov/vscode-neovim/commit/5832a73dd2a1363a03b37ff3fd3ad8c3b0bf1671, which I confirmed as my issue by patching the extension locally. According the api docs, `vscode.workspace.workspaceFolders` should return `undefined` when no folders are opened, but apparently that isn't reliable or there is something different in vscodium. Either way, this seems like a fairly safe fix