### PR TITLE
add <c-w><c-v>, <c-w><c-s>, and <c-w><c-o> commands

### DIFF
--- a/vim/vscode-window-commands.vim
+++ b/vim/vscode-window-commands.vim
@@ -48,9 +48,13 @@ AlterCommand on[ly] Only
 
 nnoremap <C-w>s <Cmd>call <SID>split('h')<CR>
 xnoremap <C-w>s <Cmd>call <SID>split('h')<CR>
+nnoremap <C-w><C-s> <Cmd>call <SID>split('h')<CR>
+xnoremap <C-w><C-s> <Cmd>call <SID>split('h')<CR>
 
 nnoremap <C-w>v <Cmd>call <SID>split('v')<CR>
 xnoremap <C-w>v <Cmd>call <SID>split('v')<CR>
+nnoremap <C-w><C-v> <Cmd>call <SID>split('v')<CR>
+xnoremap <C-w><C-v> <Cmd>call <SID>split('v')<CR>
 
 nnoremap <C-w>n <Cmd>call <SID>splitNew('h', '__vscode_new__')<CR>
 xnoremap <C-w>n <Cmd>call <SID>splitNew('h', '__vscode_new__')<CR>
@@ -62,6 +66,8 @@ xnoremap <C-w>c <Cmd>call VSCodeNotify('workbench.action.closeActiveEditor')<CR>
 
 nnoremap <C-w>o <Cmd>call VSCodeNotify('workbench.action.joinAllGroups')<CR>
 xnoremap <C-w>o <Cmd>call VSCodeNotify('workbench.action.joinAllGroups')<CR>
+nnoremap <C-w><C-o> <Cmd>call VSCodeNotify('workbench.action.joinAllGroups')<CR>
+xnoremap <C-w><C-o> <Cmd>call VSCodeNotify('workbench.action.joinAllGroups')<CR>
 
 nnoremap <C-w>j <Cmd>call VSCodeNotify('workbench.action.focusBelowGroup')<CR>
 xnoremap <C-w>j <Cmd>call VSCodeNotify('workbench.action.focusBelowGroup')<CR>


### PR DESCRIPTION
with vim, you could execute window commands without letting go of
of the ctrl key which is much more convenient and fluid than having
to let go with your pinky.