### PR TITLE
Adds ability to specify separate paths for darwin-x64 and darwin-arm64

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Please report any issues/suggestions to [vscode-neovim repository](https://githu
     -   Tip: You can install neovim-0.5.0-nightly separately for just vscode, outside of your system's package manager installation
 -   Set neovim path in the extension settings and you're good to go.
     -   **Important** you must specify full path to neovim, like `C:\Neovim\bin\nvim.exe` or `/usr/local/bin/nvim`.
-    -   **IMPORTANT 2:** the setting id is `vscode-neovim.neovimExecutablePaths.win32/linux/darwin`
+    -   **IMPORTANT 2:** the setting id is `vscode-neovim.neovimExecutablePaths.win32/linux/darwin-x64/darwin-arm64`
 -   **Important!: If you already have big & custom `init.vim` i'd recommend to wrap existing settings & plugins with [`if !exists('g:vscode')`](#determining-if-running-in-vscode-in-your-initvim) check to prevent potential breakings and problems**. If you have any problems - try with empty `init.vim` first
 
 **Neovim 0.5+** is **required**. Any version lower than that won't work. Many linux distributions have an **old** version of neovim in their package repo - always check what version are you installing.

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
                     "default": "",
                     "title": "Neovim path",
                     "markdownDescription": "*Windows, OSX, Linux in Neovim path settings won`t work if this setting is set* Full path to Neovim executable. If you have enabled `useWSL` setting, specify the Linux path to nvim executable instead.",
-                    "deprecationMessage": "This setting is deprecated. Remove this setting and use neovimExecutablePaths.win32/linux/darwin instead. If you continue to use this setting, keep in mind this setting takes precedence over neovimExecutablePaths.windows/linux/darwin and those settings won't work. If you want them to work, just remove this setting from your settings.json or make its input box in User Settings empty"
+                    "deprecationMessage": "This setting is deprecated. Remove this setting and use neovimExecutablePaths.win32/linux/darwin-x64/darwin-arm64 instead. If you continue to use this setting, keep in mind this setting takes precedence over neovimExecutablePaths.windows/linux/darwin-x64/darwin-arm64 and those settings won't work. If you want them to work, just remove this setting from your settings.json or make its input box in User Settings empty"
                 },
                 "vscode-neovim.neovimExecutablePaths.win32": {
                     "type": "string",
@@ -50,11 +50,17 @@
                     "title": "Neovim executable path on Windows",
                     "markdownDescription": "Full path to Neovim executable that should be used by the extension if running VS Code on Windows.  \nExample:  \nC:\\tools\\neovim\\Neovim\\bin\\nvim.exe (if you installed using Chocolatey)  \nIf you want to use Windows Subsystem for Linux, enable the `useWSL` setting and set `neovimExecutablePaths.linux` instead"
                 },
-                "vscode-neovim.neovimExecutablePaths.darwin": {
+                "vscode-neovim.neovimExecutablePaths.darwin-x64": {
                     "type": "string",
                     "default": "",
-                    "title": "Neovim executable path on OSX",
-                    "description": "Full path to Neovim executable that should be used by the extension if running VS Code on OSX."
+                    "title": "Neovim executable path on OSX (Intel)",
+                    "description": "Full path to Neovim executable that should be used by the extension if running VS Code on OSX with an Intel processor."
+                },
+                "vscode-neovim.neovimExecutablePaths.darwin-arm64": {
+                    "type": "string",
+                    "default": "",
+                    "title": "Neovim executable path on OSX (Apple Silicon)",
+                    "description": "Full path to Neovim executable that should be used by the extension if running VS Code on OSX with an Apple Silicon processor."
                 },
                 "vscode-neovim.neovimExecutablePaths.linux": {
                     "type": "string",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -376,7 +376,11 @@ function getSystemSpecificSetting(
     const isUseWindowsSubsystemForLinux = settings.get("useWSL");
 
     //https://github.com/microsoft/vscode/blob/master/src/vs/base/common/platform.ts#L63
-    const platform = process.platform as "win32" | "darwin" | "linux";
+    let platform = process.platform as Platform;
+
+    if (platform === "darwin" && settingPrefix === "neovimExecutablePaths") {
+        platform += "-" + process.arch;
+    }
 
     const legacyEnvironmentVariable =
         legacySetting.environmentVariableName && process.env[legacySetting.environmentVariableName];


### PR DESCRIPTION
With [`homebrew` officially supporting Apple Silicon via `/opt/homebrew` as of 3.0.0](https://brew.sh/2021/02/05/homebrew-3.0.0/), many people (myself included) will begin to manage two different homebrew prefixes across machines (example: Intel Mac issued by work, M1 Mac for personal use).

I'm very open to changing the implementation details here. I'm not married to any particular spelling of these preferences or method for checking the platform, I just want to make sure it's possible to distinguish macOS on Intel from macOS on ARM.