### PR TITLE
Add <C-s> as a keybinding to send to neovim

### DIFF
--- a/package.json
+++ b/package.json
@@ -667,6 +667,12 @@
             },
             {
                 "command": "vscode-neovim.send",
+                "key": "ctrl+s",
+                "when": "editorTextFocus && neovim.init && neovim.mode != insert && neovim.ctrlKeysNormal",
+                "args": "<C-s>"
+            },
+            {
+                "command": "vscode-neovim.send",
                 "key": "ctrl+x",
                 "when": "editorTextFocus && neovim.init && neovim.mode != insert && neovim.ctrlKeysNormal",
                 "args": "<C-x>"


### PR DESCRIPTION
Was running into issues of why <C-w><C-s> wasn't working and
realized that we have a set of keybindings we wish to send
to neovim