### PR TITLE
Enable closing parameter hints and problem popup with Escape

### DIFF
--- a/package.json
+++ b/package.json
@@ -431,7 +431,7 @@
             {
                 "command": "vscode-neovim.escape",
                 "key": "Escape",
-                "when": "editorTextFocus && neovim.init"
+                "when": "editorTextFocus && neovim.init && !markersNavigationVisible && !parameterHintsVisible"
             },
             {
                 "command": "vscode-neovim.escape",


### PR DESCRIPTION
Fixes #534 

Basically, do not capture the Escape key when parameter hints or the problem popup is open.