### PR TITLE
Fix search register paste in insert mode (#388)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1042,6 +1042,12 @@
             },
             {
                 "command": "vscode-neovim.paste-register",
+                "key": "ctrl+r /",
+                "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
+                "args": "/"
+            },
+            {
+                "command": "vscode-neovim.paste-register",
                 "key": "ctrl+r a",
                 "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert",
                 "args": "a"


### PR DESCRIPTION
Fixes #388, now you can paste from the search register in insert mode with `<C-r>`.