### PR TITLE
Add workspace to `extensionKind` (#262)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "icon": "images/icon.png",
     "publisher": "asvetliakov",
     "extensionKind": [
-        "ui"
+        "ui",
+        "workspace"
     ],
     "version": "0.0.82",
     "repository": {


### PR DESCRIPTION
Fixes #262. The user still needs to manually install neovim on the remote machine, but then this plugin should be able to work in the browser.