### PR TITLE
fix: go-to-file was not working

### DIFF
--- a/vim/vscode-code-actions.vim
+++ b/vim/vscode-code-actions.vim
@@ -42,21 +42,12 @@ nnoremap <expr> <Plug>VSCodeCommentaryLine <SID>vscodeCommentary() . '_'
 xnoremap <expr> <C-/> <SID>vscodeCommentary()
 nnoremap <expr> <C-/> <SID>vscodeCommentary() . '_'
 
-function! s:vscodeGoToDefinition(str)
-    if exists('b:vscode_controlled') && b:vscode_controlled
-        call VSCodeNotify('editor.action.' . a:str)
-    else
-        " Allow to function in help files
-        exe "normal! \<C-]>"
-    endif
-endfunction
-
 " gf/gF . Map to go to definition for now
 nnoremap K <Cmd>call VSCodeNotify('editor.action.showHover')<CR>
 nnoremap gh <Cmd>call VSCodeNotify('editor.action.showHover')<CR>
-nnoremap gf <Cmd>call <SID>vscodeGoToDefinition('revealDeclaration')<CR>
-nnoremap gd <Cmd>call <SID>vscodeGoToDefinition('revealDefinition')<CR>
-nnoremap <C-]> <Cmd>call <SID>vscodeGoToDefinition('revealDefinition')<CR>
+nnoremap gf <Cmd>call VSCodeNotify('editor.action.revealDefinition')<CR>
+nnoremap gd <Cmd>call VSCodeNotify('editor.action.revealDefinition')<CR>
+nnoremap <C-]> <Cmd>call VSCodeNotify('editor.action.revealDefinition')<CR>
 nnoremap gO <Cmd>call VSCodeNotify('workbench.action.gotoSymbol')<CR>
 nnoremap gF <Cmd>call VSCodeNotify('editor.action.peekDeclaration')<CR>
 nnoremap gD <Cmd>call VSCodeNotify('editor.action.peekDefinition')<CR>
@@ -64,9 +55,9 @@ nnoremap gH <Cmd>call VSCodeNotify('editor.action.referenceSearch.trigger')<CR>
 
 xnoremap K <Cmd>call VSCodeNotify('editor.action.showHover')<CR>
 xnoremap gh <Cmd>call VSCodeNotify('editor.action.showHover')<CR>
-xnoremap gf <Cmd>call <SID>vscodeGoToDefinition('revealDeclaration')<CR>
-xnoremap gd <Cmd>call <SID>vscodeGoToDefinition('revealDefinition')<CR>
-xnoremap <C-]> <Cmd>call <SID>vscodeGoToDefinition('revealDefinition')<CR>
+xnoremap gf <Cmd>call VSCodeNotify('editor.action.revealDefinition')<CR>
+xnoremap gd <Cmd>call VSCodeNotify('editor.action.revealDefinition')<CR>
+xnoremap <C-]> <Cmd>call VSCodeNotify('editor.action.revealDefinition')<CR>
 xnoremap gO <Cmd>call VSCodeNotify('workbench.action.gotoSymbol')<CR>
 xnoremap gF <Cmd>call VSCodeNotify('editor.action.peekDeclaration')<CR>
 xnoremap gD <Cmd>call VSCodeNotify('editor.action.peekDefinition')<CR>


### PR DESCRIPTION
I am not sure if `revealDeclaration` has been deprecated but `revealDefinition` is a better fit to replicate the 'go-to-file` feature of Neovim. 