### PR TITLE
Add notebook support

### DIFF
--- a/package.json
+++ b/package.json
@@ -429,7 +429,7 @@
             {
                 "key": "enter",
                 "command": "list.select",
-                "when": "listFocus && !inputFocus"
+                "when": "listFocus && !inputFocus && !notebookCellListFocused"
             },
             {
                 "key": "g g",
@@ -464,7 +464,7 @@
             {
                 "key": "escape",
                 "command": "list.toggleKeyboardNavigation",
-                "when": "listFocus && inputFocus && listSupportsKeyboardNavigation"
+                "when": "listFocus && inputFocus && listSupportsKeyboardNavigation && !notebookCellListFocused"
             },
             {
                 "key": "r",
@@ -548,13 +548,18 @@
             },
             {
                 "command": "vscode-neovim.escape",
-                "key": "Escape",
-                "when": "editorTextFocus && neovim.init && !markersNavigationVisible && !parameterHintsVisible && !referenceSearchVisible"
+                "key": "ctrl+[",
+                "when": "editorTextFocus && neovim.init"
             },
             {
                 "command": "vscode-neovim.escape",
-                "key": "ctrl+[",
-                "when": "editorTextFocus && neovim.init"
+                "key": "escape",
+                "when": "editorTextFocus && neovim.init && !markersNavigationVisible && !parameterHintsVisible && !referenceSearchVisible"
+            },
+            {
+                "key": "escape",
+                "command": "notebook.cell.quitEdit",
+                "when": "editorTextFocus && neovim.init && !markersNavigationVisible && !parameterHintsVisible && !referenceSearchVisible && notebookEditorFocused && neovim.mode == normal"
             },
             {
                 "key": "tab",


### PR DESCRIPTION
Fixes #210 and fixes #669

This adds basic support for notebooks (jupyter/ipython). 

It allows the enter key to focus a cell for editing in normal mode, and allows the escape key to focus the cell list while in normal mode. While the cell list, the default vscode bindings work (j/k/dd/o/y/m/etc). Also, list navigation bindings already work from this plugin (gg/G/c-u/c-d).

The vscode bindings for the cell list are not very vim-like. However, I don't think vim bindings should be introduced by this plugin, because it would have to disrupt the default y/o/etc bindings. 

Instead, I will try to add some bindings to the wiki, after I rebuild the wiki and migrate stuff from readme (on my todo list). Ideas:
- `i` works like enter but direct to insert mode
- `o/O` insert cell below/above
- `zz` center view
- fold bindings to toggle output (which reminds me, fold bindings are also on my todo)
- some binding to switch between markdown and code
- copy/cut/paste

Other things which might be nice to implement:
- navigation in normal mode moves to the next editor

About the new `escape` binding, instead of adding to the when clause of the normal escape:
I wanted to do: 
`"when": "editorTextFocus && neovim.init && !markersNavigationVisible && !parameterHintsVisible && !referenceSearchVisible && !(notebookCellFocused && neovim.mode == normal)"`
but https://github.com/microsoft/vscode/issues/91473

However, since keybindings are evaluated bottom to top, I can take advantage of that and add an interception to `notebook.cell.quitEdit` when `notebookCellFocused && neovim.mode == normal`. This is not ideal but it's the cleanest I can think of.
