### PR TITLE
Refactor package.json bindings 

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,18 +398,18 @@ To use VSCode command 'Increase/decrease current view size' instead of separate 
 
 Enabled by `useCtrlKeysForInsertMode` (default true).
 
-| Key                                         | Description                                                       | Status                            |
-| ------------------------------------------- | ----------------------------------------------------------------- | --------------------------------- |
-| <kbd>C-r</kbd> <kbd>[0-9a-z"%#*+:.-=]</kbd> | Paste from register.                                              | Works                             |
-| <kbd>C-a</kbd>                              | Paste previous inserted content.                                  | Works                             |
-| <kbd>C-o</kbd>                              | Switch to normal mode for a single command, then back.            | Works                             |
-| <kbd>C-u</kbd>                              | Delete all text till beginning of line. If empty, delete newline. | Bound to VSCode key               |
-| <kbd>C-w</kbd>                              | Delete word left.                                                 | Bound to VSCode key               |
-| <kbd>C-h</kbd>                              | Delete character left.                                            | Bound to VSCode key               |
-| <kbd>C-t</kbd>                              | Indent lines right.                                               | Bound to VSCode indent line       |
-| <kbd>C-d</kbd>                              | Indent lines left.                                                | Bound to VSCode outindent line    |
-| <kbd>C-j</kbd>                              | Insert line.                                                      | Bound to VSCode insert line after |
-| <kbd>C-c</kbd>                              | Escape.                                                           | Works                             |
+| Key                                          | Description                                                       | Status                            |
+| -------------------------------------------- | ----------------------------------------------------------------- | --------------------------------- |
+| <kbd>C-r</kbd> <kbd>[0-9a-z"%#*+:.-=/]</kbd> | Paste from register.                                              | Works                             |
+| <kbd>C-a</kbd>                               | Paste previous inserted content.                                  | Works                             |
+| <kbd>C-o</kbd>                               | Switch to normal mode for a single command, then back.            | Works                             |
+| <kbd>C-u</kbd>                               | Delete all text till beginning of line. If empty, delete newline. | Bound to VSCode key               |
+| <kbd>C-w</kbd>                               | Delete word left.                                                 | Bound to VSCode key               |
+| <kbd>C-h</kbd>                               | Delete character left.                                            | Bound to VSCode key               |
+| <kbd>C-t</kbd>                               | Indent lines right.                                               | Bound to VSCode indent line       |
+| <kbd>C-d</kbd>                               | Indent lines left.                                                | Bound to VSCode outindent line    |
+| <kbd>C-j</kbd>                               | Insert line.                                                      | Bound to VSCode insert line after |
+| <kbd>C-c</kbd>                               | Escape.                                                           | Works                             |
 
 Other keys are not supported in insert mode.
 
@@ -444,16 +444,17 @@ Refer to vim manual for their use.
 
 Always enabled.
 
-| Key                             | Desription                                                |
-| ------------------------------- | --------------------------------------------------------- |
-| <kbd>C-h</kbd>                  | Delete one character left.                                |
-| <kbd>C-w</kbd>                  | Delete word left.                                         |
-| <kbd>C-u</kbd>                  | Clear line.                                               |
-| <kbd>C-g</kbd> / <kbd>C-t</kbd> | In incsearch mode moves to next/previous result.          |
-| <kbd>C-l</kbd>                  | Add next character under the cursor to incsearch.         |
-| <kbd>C-n</kbd> / <kbd>C-p</kbd> | Go down/up history.                                       |
-| <kbd>Up</kbd> / <kbd>Down</kbd> | Select next/prev suggestion (cannot be used for history). |
-| <kbd>Tab</kbd>                  | Select suggestion.                                        |
+| Key                                          | Desription                                                |
+| -------------------------------------------- | --------------------------------------------------------- |
+| <kbd>C-r</kbd> <kbd>[0-9a-z"%#*+:.-=/]</kbd> | Paste from register.                                      |
+| <kbd>C-h</kbd>                               | Delete one character left.                                |
+| <kbd>C-w</kbd>                               | Delete word left.                                         |
+| <kbd>C-u</kbd>                               | Clear line.                                               |
+| <kbd>C-g</kbd> / <kbd>C-t</kbd>              | In incsearch mode moves to next/previous result.          |
+| <kbd>C-l</kbd>                               | Add next character under the cursor to incsearch.         |
+| <kbd>C-n</kbd> / <kbd>C-p</kbd>              | Go down/up history.                                       |
+| <kbd>Up</kbd> / <kbd>Down</kbd>              | Select next/prev suggestion (cannot be used for history). |
+| <kbd>Tab</kbd>                               | Select suggestion.                                        |
 
 ### VSCode specific bindings
 

--- a/package.json
+++ b/package.json
@@ -429,7 +429,7 @@
             {
                 "key": "enter",
                 "command": "list.select",
-                "when": "listFocus && !inputFocus"
+                "when": "listFocus && !inputFocus && !notebookCellListFocused"
             },
             {
                 "key": "g g",
@@ -464,7 +464,7 @@
             {
                 "key": "escape",
                 "command": "list.toggleKeyboardNavigation",
-                "when": "listFocus && inputFocus && listSupportsKeyboardNavigation"
+                "when": "listFocus && inputFocus && listSupportsKeyboardNavigation && !notebookCellListFocused"
             },
             {
                 "key": "r",

--- a/package.json
+++ b/package.json
@@ -554,16 +554,6 @@
                 "args": "<End>"
             },
             {
-                "command": "list.focusDown",
-                "key": "ctrl+n",
-                "when": "listFocus && !inputFocus"
-            },
-            {
-                "command": "list.focusUp",
-                "key": "ctrl+p",
-                "when": "listFocus && !inputFocus"
-            },
-            {
                 "key": "j",
                 "command": "list.focusDown",
                 "when": "listFocus && !inputFocus"
@@ -664,6 +654,31 @@
                 "when": "filesExplorerFocus && !inputFocus"
             },
             {
+                "key": "tab",
+                "command": "togglePeekWidgetFocus",
+                "when": "inReferenceSearchEditor && neovim.mode == normal || referenceSearchVisible"
+            },
+            {
+                "key": "ctrl+n",
+                "command": "list.focusDown",
+                "when": "inReferenceSearchEditor && neovim.mode == normal"
+            },
+            {
+                "key": "ctrl+p",
+                "command": "list.focusUp",
+                "when": "inReferenceSearchEditor && neovim.mode == normal"
+            },
+            {
+                "command": "list.focusDown",
+                "key": "ctrl+n",
+                "when": "listFocus && !inputFocus"
+            },
+            {
+                "command": "list.focusUp",
+                "key": "ctrl+p",
+                "when": "listFocus && !inputFocus"
+            },
+            {
                 "command": "showNextParameterHint",
                 "key": "ctrl+n",
                 "when": "editorTextFocus && parameterHintsMultipleSignatures && parameterHintsVisible"
@@ -692,21 +707,6 @@
                 "command": "workbench.action.quickOpenSelectPrevious",
                 "key": "ctrl+p",
                 "when": "inQuickOpen"
-            },
-            {
-                "key": "tab",
-                "command": "togglePeekWidgetFocus",
-                "when": "inReferenceSearchEditor && neovim.mode == normal || referenceSearchVisible"
-            },
-            {
-                "key": "ctrl+p",
-                "command": "list.focusUp",
-                "when": "inReferenceSearchEditor && neovim.mode == normal"
-            },
-            {
-                "key": "ctrl+n",
-                "command": "list.focusDown",
-                "when": "inReferenceSearchEditor && neovim.mode == normal"
             },
             {
                 "command": "vscode-neovim.send",

--- a/package.json
+++ b/package.json
@@ -893,13 +893,19 @@
                 "args": "<C-/>"
             },
             {
-                "command": "deleteAllLeft",
-                "key": "ctrl-u",
+                "command": "vscode-neovim.ctrl-o-insert",
+                "key": "ctrl+o",
                 "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert"
             },
             {
-                "command": "vscode-neovim.ctrl-o-insert",
+                "command": "vscode-neovim.send",
                 "key": "ctrl+o",
+                "when": "editorTextFocus && neovim.mode == insert && neovim.recording && neovim.ctrlKeysInsert",
+                "args": "<C-o>"
+            },
+            {
+                "command": "deleteAllLeft",
+                "key": "ctrl-u",
                 "when": "editorTextFocus && neovim.mode == insert && !neovim.recording && neovim.ctrlKeysInsert"
             },
             {

--- a/package.json
+++ b/package.json
@@ -538,33 +538,33 @@
             },
             {
                 "command": "vscode-neovim.escape",
-                "key": "ctrl+c",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert && neovim.ctrlKeysNormal"
+                "key": "ctrl+[",
+                "when": "editorTextFocus && neovim.init"
             },
             {
                 "command": "vscode-neovim.escape",
                 "key": "ctrl+c",
-                "when": "editorTextFocus && neovim.init && neovim.mode == insert && neovim.ctrlKeysInsert"
+                "when": "editorTextFocus && neovim.init && neovim.mode == normal && neovim.ctrlKeysNormal && !markersNavigationVisible && !parameterHintsVisible && !inReferenceSearchEditor && !referenceSearchVisible && !dirtyDiffVisible && !notebookCellFocused"
+            },
+            {
+                "command": "vscode-neovim.escape",
+                "key": "ctrl+c",
+                "when": "editorTextFocus && neovim.init && neovim.mode != normal && neovim.ctrlKeysInsert"
             },
             {
                 "command": "vscode-neovim.escape",
                 "key": "Escape",
-                "when": "editorTextFocus && neovim.init && !markersNavigationVisible && !parameterHintsVisible && !referenceSearchVisible"
+                "when": "editorTextFocus && neovim.init && neovim.mode == normal && !markersNavigationVisible && !parameterHintsVisible && !inReferenceSearchEditor && !referenceSearchVisible && !dirtyDiffVisible && !notebookCellFocused"
             },
             {
                 "command": "vscode-neovim.escape",
-                "key": "ctrl+[",
-                "when": "editorTextFocus && neovim.init"
+                "key": "Escape",
+                "when": "editorTextFocus && neovim.init && neovim.mode != normal"
             },
             {
                 "key": "tab",
                 "command": "togglePeekWidgetFocus",
                 "when": "inReferenceSearchEditor || referenceSearchVisible && neovim.mode == normal"
-            },
-            {
-                "key": "escape",
-                "command": "closeReferenceSearch",
-                "when": "inReferenceSearchEditor && !config.editor.stablePeek && neovim.mode == normal"
             },
             {
                 "key": "ctrl+p",

--- a/package.json
+++ b/package.json
@@ -685,13 +685,13 @@
             {
                 "command": "vscode-neovim.send",
                 "key": "tab",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert && neovim.mode != cmdline_normal",
+                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
                 "args": "<Tab>"
             },
             {
                 "command": "vscode-neovim.send",
                 "key": "shift+tab",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert && neovim.mode != cmdline_normal",
+                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
                 "args": "<S-Tab>"
             },
             {

--- a/package.json
+++ b/package.json
@@ -422,6 +422,138 @@
                 "args": "<C-S-F>"
             },
             {
+                "command": "vscode-neovim.send",
+                "key": "backspace",
+                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "args": "<BS>"
+            },
+            {
+                "command": "vscode-neovim.send",
+                "key": "shift+backspace",
+                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "args": "<S-BS>"
+            },
+            {
+                "command": "vscode-neovim.send",
+                "key": "ctrl+backspace",
+                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "args": "<C-BS>"
+            },
+            {
+                "command": "vscode-neovim.send",
+                "key": "delete",
+                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "args": "<Del>"
+            },
+            {
+                "command": "vscode-neovim.send",
+                "key": "shift+delete",
+                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "args": "<S-Del>"
+            },
+            {
+                "command": "vscode-neovim.send",
+                "key": "ctrl+delete",
+                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "args": "<C-Del>"
+            },
+            {
+                "command": "vscode-neovim.send",
+                "key": "tab",
+                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "args": "<Tab>"
+            },
+            {
+                "command": "vscode-neovim.send",
+                "key": "shift+tab",
+                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "args": "<S-Tab>"
+            },
+            {
+                "command": "vscode-neovim.send",
+                "key": "down",
+                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "args": "<Down>"
+            },
+            {
+                "command": "vscode-neovim.send",
+                "key": "up",
+                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "args": "<Up>"
+            },
+            {
+                "command": "vscode-neovim.send",
+                "key": "left",
+                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "args": "<Left>"
+            },
+            {
+                "command": "vscode-neovim.send",
+                "key": "right",
+                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "args": "<Right>"
+            },
+            {
+                "command": "vscode-neovim.send",
+                "key": "ctrl+down",
+                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "args": "<C-Down>"
+            },
+            {
+                "command": "vscode-neovim.send",
+                "key": "ctrl+up",
+                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "args": "<C-Up>"
+            },
+            {
+                "command": "vscode-neovim.send",
+                "key": "ctrl+right",
+                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "args": "<C-Right>"
+            },
+            {
+                "command": "vscode-neovim.send",
+                "key": "ctrl+left",
+                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "args": "<C-Left>"
+            },
+            {
+                "command": "vscode-neovim.send",
+                "key": "shift+down",
+                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "args": "<S-Down>"
+            },
+            {
+                "command": "vscode-neovim.send",
+                "key": "shift+up",
+                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "args": "<S-Up>"
+            },
+            {
+                "command": "vscode-neovim.send",
+                "key": "shift+left",
+                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "args": "<S-Left>"
+            },
+            {
+                "command": "vscode-neovim.send",
+                "key": "shift+right",
+                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "args": "<S-Right>"
+            },
+            {
+                "command": "vscode-neovim.send",
+                "key": "home",
+                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "args": "<Home>"
+            },
+            {
+                "command": "vscode-neovim.send",
+                "key": "end",
+                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
+                "args": "<End>"
+            },
+            {
                 "command": "list.focusDown",
                 "key": "ctrl+n",
                 "when": "listFocus && !inputFocus"
@@ -645,138 +777,6 @@
                 "command": "vscode-neovim.complete-selection-cmdline",
                 "key": "tab",
                 "when": "neovim.mode == cmdline_normal || neovim.mode == cmdline_insert || neovim.mode == cmdline_replace"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "backspace",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
-                "args": "<BS>"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "shift+backspace",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
-                "args": "<S-BS>"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "ctrl+backspace",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
-                "args": "<C-BS>"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "delete",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
-                "args": "<Del>"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "shift+delete",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
-                "args": "<S-Del>"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "ctrl+delete",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
-                "args": "<C-Del>"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "tab",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
-                "args": "<Tab>"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "shift+tab",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
-                "args": "<S-Tab>"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "down",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
-                "args": "<Down>"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "up",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
-                "args": "<Up>"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "left",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
-                "args": "<Left>"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "right",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
-                "args": "<Right>"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "ctrl+down",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
-                "args": "<C-Down>"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "ctrl+up",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
-                "args": "<C-Up>"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "ctrl+right",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
-                "args": "<C-Right>"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "ctrl+left",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
-                "args": "<C-Left>"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "shift+down",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
-                "args": "<S-Down>"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "shift+up",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
-                "args": "<S-Up>"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "shift+left",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
-                "args": "<S-Left>"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "shift+right",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
-                "args": "<S-Right>"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "home",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
-                "args": "<Home>"
-            },
-            {
-                "command": "vscode-neovim.send",
-                "key": "end",
-                "when": "editorTextFocus && neovim.init && neovim.mode != insert || neovim.recording",
-                "args": "<End>"
             },
             {
                 "command": "vscode-neovim.send",

--- a/package.json
+++ b/package.json
@@ -393,6 +393,18 @@
             },
             {
                 "command": "vscode-neovim.send",
+                "key": "ctrl+p",
+                "when": "editorTextFocus && neovim.mode == visual",
+                "args": "<C-P>"
+            },
+            {
+                "command": "vscode-neovim.send",
+                "key": "cmd+p",
+                "when": "editorTextFocus && neovim.mode == visual",
+                "args": "<C-P>"
+            },
+            {
+                "command": "vscode-neovim.send",
                 "key": "ctrl+shift+p",
                 "when": "editorTextFocus && neovim.mode == visual",
                 "args": "<C-S-P>"

--- a/package.json
+++ b/package.json
@@ -609,42 +609,42 @@
             {
                 "command": "vscode-neovim.history-up-cmdline",
                 "key": "up",
-                "when": "neovim.mode == cmdline_normal"
+                "when": "neovim.mode == cmdline_normal || neovim.mode == cmdline_insert || neovim.mode == cmdline_replace"
             },
             {
                 "command": "vscode-neovim.history-up-cmdline",
                 "key": "ctrl+p",
-                "when": "neovim.mode == cmdline_normal"
+                "when": "neovim.mode == cmdline_normal || neovim.mode == cmdline_insert || neovim.mode == cmdline_replace"
             },
             {
                 "command": "vscode-neovim.history-down-cmdline",
                 "key": "down",
-                "when": "neovim.mode == cmdline_normal"
+                "when": "neovim.mode == cmdline_normal || neovim.mode == cmdline_insert || neovim.mode == cmdline_replace"
             },
             {
                 "command": "vscode-neovim.history-down-cmdline",
                 "key": "ctrl+n",
-                "when": "neovim.mode == cmdline_normal"
+                "when": "neovim.mode == cmdline_normal || neovim.mode == cmdline_insert || neovim.mode == cmdline_replace"
             },
             {
                 "command": "vscode-neovim.delete-word-left-cmdline",
                 "key": "ctrl+w",
-                "when": "neovim.mode == cmdline_normal"
+                "when": "neovim.mode == cmdline_normal || neovim.mode == cmdline_insert || neovim.mode == cmdline_replace"
             },
             {
                 "command": "vscode-neovim.delete-all-cmdline",
                 "key": "ctrl+u",
-                "when": "neovim.mode == cmdline_normal"
+                "when": "neovim.mode == cmdline_normal || neovim.mode == cmdline_insert || neovim.mode == cmdline_replace"
             },
             {
                 "command": "vscode-neovim.delete-char-left-cmdline",
                 "key": "ctrl+h",
-                "when": "neovim.mode == cmdline_normal"
+                "when": "neovim.mode == cmdline_normal || neovim.mode == cmdline_insert || neovim.mode == cmdline_replace"
             },
             {
                 "command": "vscode-neovim.complete-selection-cmdline",
                 "key": "tab",
-                "when": "neovim.mode == cmdline_normal"
+                "when": "neovim.mode == cmdline_normal || neovim.mode == cmdline_insert || neovim.mode == cmdline_replace"
             },
             {
                 "command": "vscode-neovim.send",

--- a/package.json
+++ b/package.json
@@ -564,7 +564,7 @@
             {
                 "key": "tab",
                 "command": "togglePeekWidgetFocus",
-                "when": "inReferenceSearchEditor || referenceSearchVisible && neovim.mode == normal"
+                "when": "inReferenceSearchEditor && neovim.mode == normal || referenceSearchVisible"
             },
             {
                 "key": "ctrl+p",

--- a/package.json
+++ b/package.json
@@ -367,6 +367,31 @@
         ],
         "keybindings": [
             {
+                "command": "vscode-neovim.escape",
+                "key": "ctrl+[",
+                "when": "editorTextFocus && neovim.init"
+            },
+            {
+                "command": "vscode-neovim.escape",
+                "key": "ctrl+c",
+                "when": "editorTextFocus && neovim.init && neovim.mode == normal && neovim.ctrlKeysNormal && !markersNavigationVisible && !parameterHintsVisible && !inReferenceSearchEditor && !referenceSearchVisible && !dirtyDiffVisible && !notebookCellFocused"
+            },
+            {
+                "command": "vscode-neovim.escape",
+                "key": "ctrl+c",
+                "when": "editorTextFocus && neovim.init && neovim.mode != normal && neovim.ctrlKeysInsert"
+            },
+            {
+                "command": "vscode-neovim.escape",
+                "key": "Escape",
+                "when": "editorTextFocus && neovim.init && neovim.mode == normal && !markersNavigationVisible && !parameterHintsVisible && !inReferenceSearchEditor && !referenceSearchVisible && !dirtyDiffVisible && !notebookCellFocused"
+            },
+            {
+                "command": "vscode-neovim.escape",
+                "key": "Escape",
+                "when": "editorTextFocus && neovim.init && neovim.mode != normal"
+            },
+            {
                 "command": "vscode-neovim.send",
                 "key": "ctrl+shift+p",
                 "when": "editorTextFocus && neovim.mode == visual",
@@ -535,31 +560,6 @@
                 "command": "workbench.action.quickOpenSelectPrevious",
                 "key": "ctrl+p",
                 "when": "inQuickOpen"
-            },
-            {
-                "command": "vscode-neovim.escape",
-                "key": "ctrl+[",
-                "when": "editorTextFocus && neovim.init"
-            },
-            {
-                "command": "vscode-neovim.escape",
-                "key": "ctrl+c",
-                "when": "editorTextFocus && neovim.init && neovim.mode == normal && neovim.ctrlKeysNormal && !markersNavigationVisible && !parameterHintsVisible && !inReferenceSearchEditor && !referenceSearchVisible && !dirtyDiffVisible && !notebookCellFocused"
-            },
-            {
-                "command": "vscode-neovim.escape",
-                "key": "ctrl+c",
-                "when": "editorTextFocus && neovim.init && neovim.mode != normal && neovim.ctrlKeysInsert"
-            },
-            {
-                "command": "vscode-neovim.escape",
-                "key": "Escape",
-                "when": "editorTextFocus && neovim.init && neovim.mode == normal && !markersNavigationVisible && !parameterHintsVisible && !inReferenceSearchEditor && !referenceSearchVisible && !dirtyDiffVisible && !notebookCellFocused"
-            },
-            {
-                "command": "vscode-neovim.escape",
-                "key": "Escape",
-                "when": "editorTextFocus && neovim.init && neovim.mode != normal"
             },
             {
                 "key": "tab",

--- a/vim/vscode-code-actions.vim
+++ b/vim/vscode-code-actions.vim
@@ -83,5 +83,6 @@ xnoremap <C-w>gd <Cmd>call VSCodeNotify('editor.action.revealDefinitionAside')<C
 nnoremap z= <Cmd>call VSCodeNotify('editor.action.quickFix')<CR>
 
 " workaround for calling command picker in visual mode
+xnoremap <C-P> <Cmd>call VSCodeNotifyVisual('workbench.action.quickOpen', 1)<CR>
 xnoremap <C-S-P> <Cmd>call VSCodeNotifyVisual('workbench.action.showCommands', 1)<CR>
 xnoremap <C-S-F> <Cmd>call VSCodeNotifyVisual('workbench.action.findInFiles', 0)<CR>


### PR DESCRIPTION
I hope to solve some of the issues I have introduced and improve the vscode bindings file.

Background info: 
- keybindings are evaluated bottom to top
- the first keybinding that matches the key and when clause is selected
- `&&` has more priority than `||` in when clause, ex. `a || b && c` == `a || (b && c)`

- [x] Refactor escape bindings (fixes #677)

The way the new escape bindings work are:
- in insert mode or visual mode, escape will *always* return to normal mode
- in normal mode, if certain vscode elements are open, escape will close them. If not, it will send to neovim

Situations where escape is sent to vscode **only in normal mode**: `markersNavigationVisible, parameterHintsVisible, inReferenceSearchEditor, referenceSearchVisible, dirtyDiffVisible, notebookCellFocused`

- [x] Allow notebook cell navigation (fixes #210, fixes #669, closes #676). Makes enter select the cell editor, and allows escape to exit the cell.

- [x] Fix peek mode bindings

`inReferenceSearchEditor && neovim.mode == normal || referenceSearchVisible` evaluates to:
- if mode is normal and search editor is focused, tab moves to the reference list
- if the reference search is visible, but the editor is not focused, then either the list is focused, or the main editor is focused. Either way, tab return to the reference editor.

- [x] C-o insert mode with macro recording (fixes #679). Now, you can use C-o while recording a macro.
- [x] Send tab during recording, which can no longer be used for vscode actions like completions (I don't think it worked before). Using tab to select selections don't work, everything must be sent to neovim. The cmdline when clause is removed, because it is moved up above the `vscode-neovim.complete-selection-cmdline` line, which will take priority.

- [x] Shuffle bindings
  - Move escape bindings to the top, because they are the most interesting
  - Move send bindings to top. 
    - This combines with the existing C-S-P send bindings
    - Sending a key to neovim is not as important as doing other actions. For example, tab to navigate the peek editor needs to be below the send bindings. Therefore, move the send bindings to the top, where there is low priority.
  - Move peek bindings up, and move list c-p bindings down. This lets you use c-p and c-n to navigate completion list in reference view, without navigating the peek list accidentally. 