### PR TITLE
Fix vscode-neovim.mouseSelectionStartVisualMode

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -41,7 +41,7 @@
                         "regexp": "Compiling.*?|Compilation .*?starting"
                     },
                     "endsPattern": {
-                        "regexp": "webpack \\d+\\.\\d+\\.\\d+ compiled|Compilation .*?finished"
+                        "regexp": "Compiled .*?successfully|Compilation .*?finished"
                     }
                 }
             }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -41,7 +41,7 @@
                         "regexp": "Compiling.*?|Compilation .*?starting"
                     },
                     "endsPattern": {
-                        "regexp": "Compiled .*?successfully|Compilation .*?finished"
+                        "regexp": "webpack \\d+\\.\\d+\\.\\d+ compiled|Compilation .*?finished"
                     }
                 }
             }

--- a/src/main_controller.ts
+++ b/src/main_controller.ts
@@ -205,7 +205,7 @@ export class MainController implements vscode.Disposable {
             this.bufferManager,
             this.changeManager,
             {
-                mouseSelectionEnabled: false,
+                mouseSelectionEnabled: this.settings.mouseSelection,
             },
         );
         this.disposables.push(this.cursorManager);


### PR DESCRIPTION
It looks like #334 accidentally ignored `vscode-neovim.mouseSelectionStartVisualMode`.

Explained here: https://github.com/asvetliakov/vscode-neovim/issues/395#issuecomment-897005222

This PR re-enables that setting.