### PR TITLE
Fix command line open workspace files

### DIFF
--- a/src/buffer_manager.ts
+++ b/src/buffer_manager.ts
@@ -192,11 +192,12 @@ export class BufferManager implements Disposable, NeovimRedrawProcessable, Neovi
                 if (fileName === "__vscode_new__") {
                     doc = await workspace.openTextDocument();
                 } else {
-                    const uri = await this.getInternalUri(fileName)
+                    const normalizedName = fileName.trim();
+                    const uri = await this.getInternalUri(normalizedName);
                     if (uri) {
                         doc = await workspace.openTextDocument(uri);
                     } else {
-                        doc = await workspace.openTextDocument(fileName.trim());
+                        doc = await workspace.openTextDocument(normalizedName);
                     }
                 }
                 if (!doc) {

--- a/src/buffer_manager.ts
+++ b/src/buffer_manager.ts
@@ -594,10 +594,10 @@ export class BufferManager implements Disposable, NeovimRedrawProcessable, Neovi
     }
 
     private async getInternalUri(name: string): Promise<Uri | undefined> {
-        const files = await workspace.findFiles('**/' + name)
-        const file = files.find(f => f.fsPath.indexOf(name) !== -1)
-        if (file) {
-            return file
+        const fileUris = await workspace.findFiles('**/' + name)
+        const fileUri = fileUris[0]
+        if (fileUri) {
+            return fileUri
         }
         return undefined;
     }

--- a/src/buffer_manager.ts
+++ b/src/buffer_manager.ts
@@ -192,7 +192,12 @@ export class BufferManager implements Disposable, NeovimRedrawProcessable, Neovi
                 if (fileName === "__vscode_new__") {
                     doc = await workspace.openTextDocument();
                 } else {
-                    doc = await workspace.openTextDocument(fileName.trim());
+                    const uri = await this.getInternalUri(fileName)
+                    if (uri) {
+                        doc = await workspace.openTextDocument(uri);
+                    } else {
+                        doc = await workspace.openTextDocument(fileName.trim());
+                    }
                 }
                 if (!doc) {
                     return;
@@ -585,6 +590,15 @@ export class BufferManager implements Disposable, NeovimRedrawProcessable, Neovi
             return true;
         }
         return false;
+    }
+
+    private async getInternalUri(name: string): Promise<Uri | undefined> {
+        const files = await workspace.findFiles('**/' + name)
+        const file = files.find(f => f.fsPath.indexOf(name) !== -1)
+        if (file) {
+            return file
+        }
+        return undefined;
     }
 
     private findDocFromUri(uri: string): TextDocument | undefined {


### PR DESCRIPTION
Fixes #675

## Problem
Open commands (:e, :split, :vsplit, .etc) do not open workspace files.
This is because it tries to open the file with just the filename, but the path is also needed when opening documents in vscode.

## Solution
Resolve the workspace root folder path with the input path to get the files absolute path before opening.
This fix also works for relative and absolute paths to files outside the workspace.
