### PR TITLE
Fix jk not removing "--INSERT--"

### DIFF
--- a/src/status_line_manager.ts
+++ b/src/status_line_manager.ts
@@ -29,6 +29,7 @@ export class StatusLineManager implements Disposable, NeovimRedrawProcessable {
         batch.forEach(([name, ...args], idx) => {
             // for (const [name, ...args] of batch) {
             const firstArg = args[0] || [];
+            const lastArg = args[args.length - 1] || [];
             switch (name) {
                 case "msg_showcmd": {
                     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -70,7 +71,7 @@ export class StatusLineManager implements Disposable, NeovimRedrawProcessable {
                 }
                 case "msg_showmode": {
                     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    const [content] = firstArg as [any[]];
+                    const [content] = lastArg as [any[]];
                     let str = "";
                     if (content) {
                         for (const c of content) {


### PR DESCRIPTION
Solves #270.

It seems like there is a tiny buffer in the communication channel between neovim and vscode. As a result, there might be multiple `msg_showmode` messages a singular neovim notification (as seen in the screenshot below). This issue is likely to occur when there is an edit during the insert mode as neovim would issue several `msg_showmode` messages. However, current implementation only uses the first notification, which is the stale data indicating the mode string should still be `-- INSERT --`. This PR fixes this issue by using the latest message instead of the old one.
![image](https://user-images.githubusercontent.com/60573138/142739687-49c16a8b-ec0d-440c-ab05-4ce5580e80b9.png)
